### PR TITLE
Fix for Windows 2003

### DIFF
--- a/webview/win32.py
+++ b/webview/win32.py
@@ -303,7 +303,7 @@ def _set_ie_mode():
         ie_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r'Software\Microsoft\Internet Explorer')
         try:
             version, type = winreg.QueryValueEx(ie_key, "svcVersion")
-        except FileNotFoundError:
+        except:
             version, type = winreg.QueryValueEx(ie_key, "Version")
 
         winreg.CloseKey(ie_key)


### PR DESCRIPTION
Windows 2003 breaks with the error global name 'FileNotFoundError' is not defined in combination with Python 2.7.11. Removing 'FileNotFoundError' in the except fixes this issue.