### PR TITLE
Update cocoa.py

### DIFF
--- a/webview/cocoa.py
+++ b/webview/cocoa.py
@@ -14,6 +14,10 @@ from objc import nil
 
 from webview import OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG
 
+# This lines allow to load non-HTTPS resources, like a local app as: http://127.0.0.1:5000
+bundle = AppKit.NSBundle.mainBundle()
+info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+info['NSAppTransportSecurity'] = {'NSAllowsArbitraryLoads': YES}
 
 
 class BrowserView:


### PR DESCRIPTION
Patch that allow to load non-SSL resources. It's useful to load local apps (like Flask, Django or similar) without SSL certificate.