### PR TITLE
Add Gtk and Qt implementations of load_string.

### DIFF
--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -103,16 +103,15 @@ def load_url(url):
     except NameError:
         raise Exception("Create a web view window first, before invoking this function")
 
-def load_string(content, mime_type="text/html", encoding="utf-8", base_uri=""):
+def load_html(content, base_uri=""):
     """
     Load a new content into a previously created WebView window. This function must be invoked after WebView windows is
     created with create_window(). Otherwise an exception is thrown.
     :param content: Content to load.
-    :param mime_type: MIME type of content. Default is "text/html".
     :param base_uri: Base URI for resolving links. Default is "".
     """
     try:
-        gui.load_string(_make_unicode(content), mime_type, encoding, base_uri)
+        gui.load_html(_make_unicode(content), base_uri)
     except NameError:
         raise Exception("Create a web view window first, before invoking this function")
 

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -103,8 +103,21 @@ def load_url(url):
     except NameError:
         raise Exception("Create a web view window first, before invoking this function")
 
+def load_string(content, mime_type="text/html", encoding="utf-8", base_uri=""):
+    """
+    Load a new content into a previously created WebView window. This function must be invoked after WebView windows is
+    created with create_window(). Otherwise an exception is thrown.
+    :param content: Content to load.
+    :param mime_type: MIME type of content. Default is "text/html".
+    :param base_uri: Base URI for resolving links. Default is "".
+    """
+    try:
+        gui.load_string(_make_unicode(content), mime_type, encoding, base_uri)
+    except NameError:
+        raise Exception("Create a web view window first, before invoking this function")
 
-def create_window(title, url, width=800, height=600, resizable=True, fullscreen=False, min_size=(200, 100)):
+
+def create_window(title, url=None, width=800, height=600, resizable=True, fullscreen=False, min_size=(200, 100)):
     """
     Create a web view window using a native GUI. The execution blocks after this function is invoked, so other
     program logic must be executed in a separate thread.
@@ -142,6 +155,8 @@ def _make_unicode(string):
 
 
 def _transform_url(url):
+    if url == None:
+        return url
     if url.find(":") == -1:
         return 'file://' + os.path.abspath(url)
     else:

--- a/webview/cocoa.py
+++ b/webview/cocoa.py
@@ -243,6 +243,8 @@ def create_file_dialog(dialog_type, directory, allow_multiple, save_filename):
 def load_url(url):
     BrowserView.instance.load_url(url)
 
+def load_string(content, mime_type, base_uri):
+    raise NotImplementedError
 
 def destroy_window():
     BrowserView.instance.destroy()

--- a/webview/gtk.py
+++ b/webview/gtk.py
@@ -114,8 +114,9 @@ class BrowserView:
     def load_url(self, url):
         self.webview.load_uri(url)
 
-    def load_string(self, content, mime_type, encoding, base_uri):
-        glib.idle_add(self.webview.load_string, content, mime_type, encoding, base_uri)
+    def load_html(self, content, base_uri):
+        glib.idle_add(self.webview.load_string, content, "text/html", "utf-8",
+                      base_uri)
 
 
 def create_window(title, url, width, height, resizable, fullscreen, min_size):
@@ -130,8 +131,8 @@ def destroy_window():
 def load_url(url):
     BrowserView.instance.load_url(url)
 
-def load_string(content, mime_type, encoding, base_uri=""):
-    BrowserView.instance.load_string(content, mime_type, encoding, base_uri)
+def load_html(content, base_uri):
+    BrowserView.instance.load_html(content, base_uri)
 
 
 def create_file_dialog(dialog_type, directory, allow_multiple, save_filename):

--- a/webview/gtk.py
+++ b/webview/gtk.py
@@ -14,6 +14,7 @@ try:
     # Try GTK 3
     from gi.repository import Gtk as gtk
     from gi.repository import Gdk
+    from gi.repository import GLib as glib
     from gi.repository import WebKit as webkit
 except ImportError as e:
     import_error = True
@@ -52,7 +53,9 @@ class BrowserView:
         webview.props.settings.props.enable_default_context_menu = False
         scrolled_window.add_with_viewport(webview)
         window.show_all()
-        webview.load_uri(url)
+
+        if url != None:
+            webview.load_uri(url)
 
         self.window = window
         self.webview = webview
@@ -111,6 +114,9 @@ class BrowserView:
     def load_url(self, url):
         self.webview.load_uri(url)
 
+    def load_string(self, content, mime_type, encoding, base_uri):
+        glib.idle_add(self.webview.load_string, content, mime_type, encoding, base_uri)
+
 
 def create_window(title, url, width, height, resizable, fullscreen, min_size):
     browser = BrowserView(title, url, width, height, resizable, fullscreen, min_size)
@@ -123,6 +129,9 @@ def destroy_window():
 
 def load_url(url):
     BrowserView.instance.load_url(url)
+
+def load_string(content, mime_type, encoding, base_uri=""):
+    BrowserView.instance.load_string(content, mime_type, encoding, base_uri)
 
 
 def create_file_dialog(dialog_type, directory, allow_multiple, save_filename):

--- a/webview/qt.py
+++ b/webview/qt.py
@@ -50,7 +50,7 @@ if _import_error:
 class BrowserView(QMainWindow):
     instance = None
     url_trigger = QtCore.pyqtSignal(str)
-    string_trigger = QtCore.pyqtSignal(str, str, str, str)
+    html_trigger = QtCore.pyqtSignal(str, str)
     dialog_trigger = QtCore.pyqtSignal(int, str, bool, str)
     destroy_trigger = QtCore.pyqtSignal()
 
@@ -78,7 +78,7 @@ class BrowserView(QMainWindow):
 
         self.setCentralWidget(self.view)
         self.url_trigger.connect(self._handle_load_url)
-        self.string_trigger.connect(self._handle_load_string)
+        self.html_trigger.connect(self._handle_load_html)
         self.dialog_trigger.connect(self._handle_file_dialog)
         self.destroy_trigger.connect(self._handle_destroy_window)
 
@@ -105,15 +105,8 @@ class BrowserView(QMainWindow):
     def _handle_load_url(self, url):
         self.view.setUrl(QtCore.QUrl(url))
 
-    def _handle_load_string(self, content, mime_type, encoding, base_uri):
-        # Qt will convert Python string to QStrings (except in Python 3)
-        if sys.version < '3':
-            # unpack the QString and convert to UTF-16
-            data = unicode(content).encode("utf-16")
-        else:
-            # convert to UTF-16
-            data = content.encode("utf-16")
-        self.view.setContent(data, mime_type, QtCore.QUrl(base_uri))
+    def _handle_load_html(self, content, base_uri):
+        self.view.setHtml(content, QtCore.QUrl(base_uri))
 
     def _handle_destroy_window(self):
         self.close()
@@ -121,8 +114,8 @@ class BrowserView(QMainWindow):
     def load_url(self, url):
         self.url_trigger.emit(url)
 
-    def load_string(self, content, mime_type, encoding, base_uri):
-        self.string_trigger.emit(content, mime_type, encoding, base_uri)
+    def load_html(self, content, base_uri):
+        self.html_trigger.emit(content, base_uri)
 
     def create_file_dialog(self, dialog_type, directory, allow_multiple, save_filename):
         self.dialog_trigger.emit(dialog_type, directory, allow_multiple, save_filename)
@@ -166,8 +159,8 @@ def create_window(title, url, width, height, resizable, fullscreen, min_size):
 def load_url(url):
     BrowserView.instance.load_url(url)
 
-def load_string(content, mime_type, encoding, base_uri=""):
-    BrowserView.instance.load_string(content, mime_type, encoding, base_uri)
+def load_html(content, base_uri):
+    BrowserView.instance.load_html(content, base_uri)
 
 def destroy_window():
     BrowserView.instance.destroy_()

--- a/webview/win32.py
+++ b/webview/win32.py
@@ -288,6 +288,8 @@ def create_file_dialog(dialog_type, directory, allow_multiple, save_filename):
 def load_url(url):
     BrowserView.instance.load_url(url)
 
+def load_string(content, mime_type, base_uri):
+    raise NotImplementedError
 
 def destroy_window():
     BrowserView.instance.destroy()


### PR DESCRIPTION
This adds load_string for the Gtk and Qt versions. Cocoa and Win32 versions throw NotImplementedErrors.

The added function has parameters:
`load_string(unicode_content, mime_type="text/html", encoding="utf-8", base_uri="")`

In the Gtk version, 'encoding' changes the encoding of the entire webview. This is not supported in Qt, but the parameter is passed in anyway (and ignored).

Example usage:

    # Python 2
    webview.load_string(u"日本")
    # Python 3
    webview.load_string("日本")`

If the string is not unicode in Python 2, it is converted for the user.
