### PR TITLE
This commit fixed an issue when trying to import PyQt5

### DIFF
--- a/webview/qt.py
+++ b/webview/qt.py
@@ -32,7 +32,14 @@ else:
 if _import_error:
     try:
         from PyQt5 import QtCore
-        from PyQt5.QtWebKitWidgets import QWebView
+
+        # Check to see if we're running Qt > 5.5
+        from PyQt5.QtCore import QT_VERSION_STR
+        if float(QT_VERSION_STR[:3]) > 5.5:
+            from PyQt5.QtWebEngineWidgets import QWebEngineView as QWebView
+        else:
+            from PyQt5.QtWebKitWidgets import QWebView
+
         from PyQt5.QtWidgets import QWidget, QMainWindow, QVBoxLayout, QApplication, QFileDialog
 
         logger.debug("Using Qt5")


### PR DESCRIPTION
This commit fixed an issue when trying to import PyQt5's QWebView modules which led 
to a false positive that 'PyQt5 was not found' on Linux systems, this is
due to the fact that QtWebKitWidgets has been deprecated in Qt 5.5 and
eventually removed in Qt 5.6 in
favour of QtWebEngineWidgets. There's an extensive guide in the Qt docs
on how to port an application that used the old QWebView to the new
QWebEngineView.
http://doc.qt.io/qt-5/qtwebenginewidgets-qtwebkitportingguide.html

Linux Users who run Arch, Fedora or bleeding edge software generally
will be affected by this issue as they'll probably have a version of Qt that's
greater than 5.5