### PR TITLE
Fix gtk window

### DIFF
--- a/webview/gtk.py
+++ b/webview/gtk.py
@@ -59,7 +59,7 @@ class BrowserView:
         window.show_all()
 
         if url != None:
-            webview.load_uri(url)
+            self.webview.load_uri(url)
 
     def _handle_webview_ready(self, arg1, arg2):
         self.webview_ready.set()


### PR DESCRIPTION
Seems to be broken after the latest update. I was seeing this message every time I tried to run pywebview:

Traceback (most recent call last):
  File "webview-test.py", line 2, in <module>
    webview.create_window("It works jim", "http://flowrl.com")
  File "/usr/lib/python3.5/site-packages/webview/__init__.py", line 160, in create_window
    gui.create_window(_make_unicode(title), _transform_url(url), width, height, resizable, fullscreen, min_size, _webview_ready)
  File "/usr/lib/python3.5/site-packages/webview/gtk.py", line 127, in create_window
    browser = BrowserView(title, url, width, height, resizable, fullscreen, min_size, webview_ready)
  File "/usr/lib/python3.5/site-packages/webview/gtk.py", line 62, in __init__
    webview.load_uri(url)
NameError: name 'webview' is not defined
