### PR TITLE
Fix resizing width/height: 100% problem on GTK

### DIFF
--- a/webview/gtk.py
+++ b/webview/gtk.py
@@ -55,7 +55,7 @@ class BrowserView:
         self.webview = webkit.WebView()
         self.webview.connect("notify::visible", self._handle_webview_ready)
         self.webview.props.settings.props.enable_default_context_menu = False
-        scrolled_window.add_with_viewport(self.webview)
+        scrolled_window.add(self.webview)
         window.show_all()
 
         if url != None:


### PR DESCRIPTION
On GTK when body with/height is set to 100% in CSS after increasing the window size one could not resize content back to smaller size. I showed it on videos.

[before change](http://tinypic.com/r/iojhxs/9)
[after change](http://tinypic.com/r/ip3w2b/9)

What was the motivation for the changed line to be `add_with_viewport` instead of just `add`?