### PR TITLE
Qt4/5 fallback for Macs with Qt and no PyObjC

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ To automatically fetch and install Python dependencies for your platform, instal
 
 On Windows (using WinForms with `pythonnet`):
 
-    pip install pywebview[windows]
+    pip install pywebview[winforms]
 
-On Mac (using the platform WebKit widgets via `pyobjc`):
+On Mac (using the Cocoa WebKit widget via `pyobjc`):
 
-    pip install pywebview[mac]
+    pip install pywebview[cocoa]
 
 On Linux (using GTK3 via `PyGObject`):
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,17 @@ Traktor Librarian: http://flowrl.com/librarian/
 
 # Installation
 
+If you have the [dependencies](#dependencies) installed, simply:
+
     pip install pywebview
 
+To automatically fetch and install Python dependencies for your platform, install with the appropriate ["install extras"](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies):
+
+    pip install pywebview[win32]  # for pywin32 + comtypes
+    pip intsall pywebview[winforms]  # WinForms with pythonnet
+    pip intsall pywebview[mac]  # Mac native WebKit view with PyObjC
+    pip intsall pywebview[qt4]  # Qt4 with PyQt4
+    pip intsall pywebview[qt5]  # Qt5 with PyQt5
 
 # Contributions and bug reports
 

--- a/README.md
+++ b/README.md
@@ -17,20 +17,36 @@ Apps created with pywebview. If you have built an app using pywebview, please do
 Next for Traktor: http://flowrl.com/next
 Traktor Librarian: http://flowrl.com/librarian/
 
-
 # Installation
 
 If you have the [dependencies](#dependencies) installed, simply:
 
     pip install pywebview
 
-To automatically fetch and install Python dependencies for your platform, install with the appropriate ["install extras"](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies):
+To automatically fetch and install Python dependencies for your platform, install with the appropriate ["install extras"](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies).
 
-    pip install pywebview[win32]  # for pywin32 + comtypes
-    pip intsall pywebview[winforms]  # WinForms with pythonnet
-    pip intsall pywebview[mac]  # Mac native WebKit view with PyObjC
-    pip intsall pywebview[qt4]  # Qt4 with PyQt4
-    pip intsall pywebview[qt5]  # Qt5 with PyQt5
+(Note that the same code is installed regardless; if more than one of the libraries below are available they will be tried in the order listed in this readme.)
+
+On Windows (using WinForms with `pythonnet`):
+
+    pip install pywebview[windows]
+
+On Mac (using the platform WebKit widgets via `pyobjc`):
+
+    pip install pywebview[mac]
+
+On Linux (using GTK3 via `PyGObject`):
+
+    pip install pywebview[gtk3]
+
+On Linux or Mac with either Qt 4 or 5:
+
+    pip install pywebview[qt4]  # Qt4 with PyQt4
+    pip install pywebview[qt5]  # Qt5 with PyQt5
+
+A second implementation for Windows using `pywin32` and `comtypes` is also available:
+
+    pip install pywebview[win32]
 
 # Contributions and bug reports
 

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ from setuptools import setup
 if platform.system() == "Windows":
     extras_require = {
         'win32': ['pywin32', 'comtypes'],
-        'windows': ['pythonnet'],
+        'winforms': ['pythonnet'],
     }
 elif platform.system() == "Darwin":
     extras_require = {
-        'mac': ['pyobjc'],
+        'cocoa': ['pyobjc'],
         'qt4': ['PyQt4'],
         'qt5': ['PyQt5'],
     }

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,23 @@ import os
 import platform
 from setuptools import setup
 
-install_requires = []
 if platform.system() == "Windows":
-    install_requires = []
+    extras_require = {
+        'win32': ['pywin32', 'comtypes'],
+        'winforms': ['pythonnet'],
+    }
 elif platform.system() == "Darwin":
-    install_requires = ["pyobjc"]
+    extras_require = {
+        'mac': ['pyobjc'],
+        'qt4': ['PyQt4'],
+        'qt5': ['PyQt5'],
+    }
 elif platform.system() == "Linux":
-    install_requires = []
+    extras_require = {
+        'gtk3': ['PyGObject'],
+        'qt4': ['PyQt4'],
+        'qt5': ['PyQt5'],
+    }
 
 setup(
     name="pywebview",
@@ -18,7 +28,7 @@ setup(
     url="http://github.com/r0x0r/pywebview",
     download_url="https://github.com/r0x0r/pywebview/archive/1.3.tar.gz",
     keywords=["gui", "webkit", "html", "web"],
-    install_requires=install_requires,
+    extras_require=extras_require,
     version="1.3",
     packages=["webview",],
     license="New BSD license",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 if platform.system() == "Windows":
     extras_require = {
         'win32': ['pywin32', 'comtypes'],
-        'winforms': ['pythonnet'],
+        'windows': ['pythonnet'],
     }
 elif platform.system() == "Darwin":
     extras_require = {

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -44,13 +44,18 @@ def _initialize_imports():
             try:
                 import webview.cocoa as gui
             except ImportError:
+                import_error = True
+            else:
+                import_error = False
+
+            if import_error or config["USE_QT"]:
                 try:
                     import webview.qt as gui
                     logger.info("Using QT")
                 except ImportError as e:
                     # Panic
                     logger.exception("QT not found")
-                    raise Exception("You must have either QT or GTK with Python extensions installed in order to this library.")
+                    raise Exception("You must have either PyObjC (for Cocoa support) or Qt with Python bindings installed in order to use this library.")
         elif platform.system() == "Linux":
             try:
                 #Try GTK first unless USE_QT flag is set
@@ -71,7 +76,7 @@ def _initialize_imports():
                 except ImportError as e:
                     # Panic
                     logger.exception("QT not found")
-                    raise Exception("You must have either QT or GTK with Python extensions installed in order to this library.")
+                    raise Exception("You must have either QT or GTK with Python extensions installed in order to use this library.")
 
         elif platform.system() == "Windows":
 
@@ -94,7 +99,7 @@ def _initialize_imports():
                 except ImportError as e:
                     # Panic
                     logger.exception(" not found")
-                    raise Exception("You must have either pythonnet or pywin32 installed in order to this library.")
+                    raise Exception("You must have either pythonnet or pywin32 installed in order to use this library.")
         else:
             raise Exception("Unsupported platform. Only Windows, Linux and OS X are supported.")
 

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -41,9 +41,17 @@ def _initialize_imports():
 
     if not _initialized:
         if platform.system() == "Darwin":
-            import webview.cocoa as gui
+            try:
+                import webview.cocoa as gui
+            except ImportError:
+                try:
+                    import webview.qt as gui
+                    logger.info("Using QT")
+                except ImportError as e:
+                    # Panic
+                    logger.exception("QT not found")
+                    raise Exception("You must have either QT or GTK with Python extensions installed in order to this library.")
         elif platform.system() == "Linux":
-
             try:
                 #Try GTK first unless USE_QT flag is set
                 if not config["USE_QT"]:


### PR DESCRIPTION
See #62. This also uses ["install extras"](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) to specify which "flavor" of pywebview to install. If the dependencies are already present, installation proceeds just as before.