### PR TITLE
Error when trying to use PYQT5

### DIFF
--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -67,7 +67,7 @@ def _initialize_imports():
                 logger.exception("GTK not found")
                 import_error = True
             else:
-                import_error = False
+                import_error = False or gui.import_error
 
             if import_error or config["USE_QT"]:
                 try:


### PR DESCRIPTION
Hi there,

I just created a Ubuntu 16.10, python 3.6 virtualenv environment and I couldn't use pywebview with the PyQT option.
On init import_error would always be False (because the error when importing the gui was caught in the module).

I am not sure this is the best way to solve this issue, but I am sharing what worked for me.  

