### PR TITLE
This fixes no attribute '_handle_current_url' in qt.py

### DIFF
--- a/webview/qt.py
+++ b/webview/qt.py
@@ -119,7 +119,7 @@ class BrowserView(QMainWindow):
 
         self._file_name_semaphor.release()
 
-    def _handle_get_current_url(self):
+    def _handle_current_url(self):
         self._current_url = self.view.url().toString()
         self._current_url_semaphore.release()
 


### PR DESCRIPTION
Renamed _handle_get_current_url function to _handle_current_url in order to use qt version of webkit.  This fixes #85 