### PR TITLE
Disable delete key back-navigation in Cocoa. Fixes #102.

### DIFF
--- a/webview/cocoa.py
+++ b/webview/cocoa.py
@@ -85,6 +85,25 @@ class BrowserView:
 
             PyObjCTools.AppHelper.callAfter(printView, frameview)
 
+        # WebPolicyDelegate method, invoked when a navigation decision needs to be made
+        def webView_decidePolicyForNavigationAction_request_frame_decisionListener_(self, webview, action, request, frame, listener):
+            # The event that might have triggered the navigation
+            event = AppKit.NSApp.currentEvent()
+            action_type = action['WebActionNavigationTypeKey'] 
+
+            """ Disable back navigation on pressing the Delete key: """
+            # Check if the requested navigation action is Back/Forward
+            if action_type == WebKit.WebNavigationTypeBackForward:
+                # Check if the event is a Delete key press (keyCode = 51)
+                if event and event.type() == AppKit.NSKeyDown and event.keyCode() == 51:
+                    # If so, ignore the request and return
+                    listener.ignore()
+                    return
+
+            # Normal navigation, allow
+            listener.use()
+
+
     class WebKitHost(WebKit.WebView):
         def performKeyEquivalent_(self, theEvent):
             """
@@ -152,6 +171,7 @@ class BrowserView:
         self._appDelegate = BrowserView.AppDelegate.alloc().init()
         self.webkit.setUIDelegate_(self._browserDelegate)
         self.webkit.setFrameLoadDelegate_(self._browserDelegate)
+        self.webkit.setPolicyDelegate_(self._browserDelegate)
         self.window.setDelegate_(self._windowDelegate)
         BrowserView.app.setDelegate_(self._appDelegate)
 


### PR DESCRIPTION
Prior to this commit, pressing the Delete key on the Mac keyboard caused
the WebView to navigate to the previous HTML page, which is undesirable
in a desktop application.

This fix makes use of the WebView's policyDelegate to refuse a back-
navigation actions if it was triggered by pressing the Delete key.
This is most convinient for two reasons:

1. We need not worry about Delete key press events that may occur
at other places (say inside text-fields).
2. Back navigation triggered explicitly via other means (like the
JavaScript history.back() method) can be allowed gracefully.

Note: attempts to capture the keypress via the WebView's keyDown method
fails because the parent NSWindow automatically assigns a subview called
WebHTMLView as the firstResponder to keyDown events, which handles
Delete key press events itself.