### PR TITLE
Like Safari, remove default margins while printing

### DIFF
--- a/webview/cocoa.py
+++ b/webview/cocoa.py
@@ -79,7 +79,28 @@ class BrowserView:
                     frameview.printDocumentView()
                 else:
                     # get an NSPrintOperaion object to print the view
-                    info = AppKit.NSPrintInfo.sharedPrintInfo()
+                    info = AppKit.NSPrintInfo.sharedPrintInfo().copy()
+
+                    # default print settings used by Safari
+                    info.setHorizontalPagination_(AppKit.NSFitPagination)
+                    info.setHorizontallyCentered_(Foundation.NO)
+                    info.setVerticallyCentered_(Foundation.NO)
+
+                    imageableBounds = info.imageablePageBounds()
+                    paperSize = info.paperSize()
+                    if (Foundation.NSWidth(imageableBounds) > paperSize.width):
+                        imageableBounds.origin.x = 0
+                        imageableBounds.size.width = paperSize.width
+                    if (Foundation.NSHeight(imageableBounds) > paperSize.height):
+                        imageableBounds.origin.y = 0
+                        imageableBounds.size.height = paperSize.height
+
+                    info.setBottomMargin_(Foundation.NSMinY(imageableBounds))
+                    info.setTopMargin_(paperSize.height - Foundation.NSMinY(imageableBounds) - Foundation.NSHeight(imageableBounds))
+                    info.setLeftMargin_(Foundation.NSMinX(imageableBounds))
+                    info.setRightMargin_(paperSize.width - Foundation.NSMinX(imageableBounds) - Foundation.NSWidth(imageableBounds))
+
+                    # show the print panel
                     print_op = frameview.printOperationWithPrintInfo_(info)
                     print_op.runOperation()
 


### PR DESCRIPTION
Don't know if this fix is relevant to Pywebview. I implemented it
for my own app using Pywebview. Thought I would share.

Oh, and this is like a follow-up to PR #98.