### PR TITLE
[GTK] Add hex color format check

### DIFF
--- a/webview/gtk.py
+++ b/webview/gtk.py
@@ -5,6 +5,7 @@ Licensed under BSD license
 http://github.com/r0x0r/pywebview/
 """
 
+import re
 import logging
 from webview.localization import localization
 from webview import OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG
@@ -44,16 +45,19 @@ class BrowserView:
         window.set_resizable(resizable)
         window.set_position(gtk.WindowPosition.CENTER)
 
-        # Set window background color
-        style_provider = gtk.CssProvider()
-        style_provider.load_from_data(
-            'GtkWindow {{ background-color: {}; }}'.format(background_color)
-        )
-        gtk.StyleContext.add_provider_for_screen(
-            Gdk.Screen.get_default(),
-            style_provider,
-            gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        )
+        # Check if background_color is in valid hex format
+        hex_pattern = r'^#(?:[0-9a-fA-F]{3}){1,2}$'
+        if re.match(hex_pattern, background_color):
+            # Set window background color
+            style_provider = gtk.CssProvider()
+            style_provider.load_from_data(
+                'GtkWindow {{ background-color: {}; }}'.format(background_color).encode()
+            )
+            gtk.StyleContext.add_provider_for_screen(
+                Gdk.Screen.get_default(),
+                style_provider,
+                gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            )
 
         scrolled_window = gtk.ScrolledWindow()
         window.add(scrolled_window)


### PR DESCRIPTION
GLib throws an error when the background_color string is not in valid
hex format. This fix adds a format check using a regex like we did in
`cocoa.py`.

Also fix Python 3.x error: "Gtk.CssProvider.load_from_data TypeError:
Item 0: Must be number, not str" (which caused the build fail on Travis).