### PR TITLE
[All] Change window close behaviour so that it returns control back instead of terminating

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -70,10 +70,10 @@ def _destroy_window(webview, delay=0):
         time.sleep(delay)
         webview.destroy_window()
 
-        #if sys.platform == 'darwin':
-        #    from .util_cocoa import mouseMoveRelative
+        if sys.platform == 'darwin':
+            from .util_cocoa import mouseMoveRelative
 
-         #   mouseMoveRelative(1, 1)
+            mouseMoveRelative(1, 1)
 
     event = threading.Event()
     event.clear()

--- a/tests/util.py
+++ b/tests/util.py
@@ -70,10 +70,10 @@ def _destroy_window(webview, delay=0):
         time.sleep(delay)
         webview.destroy_window()
 
-        if sys.platform == 'darwin':
-            from .util_cocoa import mouseMoveRelative
+        #if sys.platform == 'darwin':
+        #    from .util_cocoa import mouseMoveRelative
 
-            mouseMoveRelative(1, 1)
+         #   mouseMoveRelative(1, 1)
 
     event = threading.Event()
     event.clear()

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -151,7 +151,7 @@ def create_window(title, url=None, js_api=None, width=800, height=600,
     :param title: Window title
     :param url: URL to load
     :param width: window width. Default is 800px
-    :param height:window h  eight. Default is 600px
+    :param height:window height. Default is 600px
     :param resizable True if window can be resized, False otherwise. Default is True
     :param fullscreen: True if start in fullscreen mode. Default is False
     :param min_size: a (width, height) tuple that specifies a minimum window size. Default is 200x100

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -151,7 +151,7 @@ def create_window(title, url=None, js_api=None, width=800, height=600,
     :param title: Window title
     :param url: URL to load
     :param width: window width. Default is 800px
-    :param height:window height. Default is 600px
+    :param height:window h  eight. Default is 600px
     :param resizable True if window can be resized, False otherwise. Default is True
     :param fullscreen: True if start in fullscreen mode. Default is False
     :param min_size: a (width, height) tuple that specifies a minimum window size. Default is 200x100
@@ -161,21 +161,23 @@ def create_window(title, url=None, js_api=None, width=800, height=600,
     :param text_select: Allow text selection on page. Default is False.
     :return: The uid of the created window.
     """
-    uid = 'child_' + uuid4().hex[:8]
 
     valid_color = r'^#(?:[0-9a-fA-F]{3}){1,2}$'
     if not re.match(valid_color, background_color):
         raise ValueError('{0} is not a valid hex triplet color'.format(background_color))
 
     if not _initialized:
-        # Check if starting up from main thread; if not, wait; finally raise exception
-        if current_thread().name != 'MainThread':
-            if not _webview_ready.wait(5):
-                raise Exception('Call create_window from the main thread first, and then from subthreads')
-        else:
-            _initialize_imports()
-            localization.update(strings)
-            uid = 'master'
+        _initialize_imports()
+        localization.update(strings)
+
+    # Check if starting up from main thread; if not, wait; finally raise exception
+    if current_thread().name == 'MainThread':
+        uid = 'master'
+    else:
+        uid = 'child_' + uuid4().hex[:8]
+
+        if not _webview_ready.wait(5):
+            raise Exception('Call create_window from the main thread first, and then from subthreads')
 
     _webview_ready.clear()  # Make API calls wait while the new window is created
     gui.create_window(uid, make_unicode(title), transform_url(url),

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -166,13 +166,13 @@ def create_window(title, url=None, js_api=None, width=800, height=600,
     if not re.match(valid_color, background_color):
         raise ValueError('{0} is not a valid hex triplet color'.format(background_color))
 
-    if not _initialized:
-        _initialize_imports()
-        localization.update(strings)
-
     # Check if starting up from main thread; if not, wait; finally raise exception
     if current_thread().name == 'MainThread':
         uid = 'master'
+
+        if not _initialized:
+            _initialize_imports()
+            localization.update(strings)
     else:
         uid = 'child_' + uuid4().hex[:8]
 

--- a/webview/cocoa.py
+++ b/webview/cocoa.py
@@ -42,6 +42,10 @@ class BrowserView:
         def applicationShouldTerminateAfterLastWindowClosed_(self, sender):
             return Foundation.YES
 
+        def applicationShouldTerminate_(self, sender):
+            sender.stop_(self)
+            return False
+
     class WindowDelegate(AppKit.NSObject):
         def windowShouldClose_(self, window):
             i = BrowserView.get_instance('window', window)
@@ -185,7 +189,7 @@ class BrowserView:
             # Add the webview to the window if it's not yet the contentView
             i = BrowserView.get_instance('webkit', webview)
 
-            if not webview.window():
+            if i and not webview.window():
                 i.window.setContentView_(webview)
                 i.window.makeFirstResponder_(webview)
 
@@ -246,7 +250,7 @@ class BrowserView:
                             responder.undoManager().undo()
                             handled = True
                     elif keyCode == 12:  # quit
-                        BrowserView.app.terminate_(self)
+                        BrowserView.app.stop_(self)
 
                     return handled
 
@@ -321,6 +325,7 @@ class BrowserView:
 
             BrowserView.app.activateIgnoringOtherApps_(Foundation.YES)
             BrowserView.app.run()
+            pass
         else:
             self.webview_ready.set()
 

--- a/webview/cocoa.py
+++ b/webview/cocoa.py
@@ -325,7 +325,6 @@ class BrowserView:
 
             BrowserView.app.activateIgnoringOtherApps_(Foundation.YES)
             BrowserView.app.run()
-            pass
         else:
             self.webview_ready.set()
 

--- a/webview/gtk.py
+++ b/webview/gtk.py
@@ -54,6 +54,7 @@ class BrowserView:
         self.js_result_semaphores = []
         self.eval_js_lock = Lock()
         self.load_event = Event()
+        self.load_event.clear()
 
         glib.threads_init()
         self.window = gtk.Window(title=title)
@@ -111,7 +112,7 @@ class BrowserView:
 
         if url is not None:
             self.webview.load_uri(url)
-        else:
+        elif js_api is None:
             self.load_event.set()
 
         if fullscreen:
@@ -295,7 +296,7 @@ class BrowserView:
             return None
 
         result = self.webview.get_title()
-        result = None if result == 'undefined' or result == 'null' else result if result == '' else json.loads(result)
+        result = None if result == 'undefined' or result == 'null' or result is None else result if result == '' else json.loads(result)
 
         # Restore document title and return
         code = 'document.title = window.oldTitle{0}'.format(unique_id)

--- a/webview/qt.py
+++ b/webview/qt.py
@@ -134,7 +134,7 @@ class BrowserView(QMainWindow):
                 url = 'http://localhost:{}'.format(BrowserView.inspector_port)
 
                 inspector = BrowserView(uid, title, url, 700, 500, True, False, (300,200),
-                                        False, '#fff', False, None, self.parent().webview_ready)
+                                        False, '#fff', False, None, True, self.parent().webview_ready)
                 inspector.show()
 
     # New-window-requests handler for Qt 5.5+ only
@@ -285,11 +285,14 @@ class BrowserView(QMainWindow):
         event.accept()
         del BrowserView.instances[self.uid]
 
-        try:    # Close inpsector if open
+        try:    # Close inspector if open
             BrowserView.instances[self.uid + '-inspector'].close()
             del BrowserView.instances[self.uid + '-inspector']
         except KeyError:
             pass
+
+        if len(BrowserView.instances) == 0:
+            _app.exit()
 
     def on_destroy_window(self):
         self.close()
@@ -453,7 +456,8 @@ class BrowserView(QMainWindow):
 
 def create_window(uid, title, url, width, height, resizable, fullscreen, min_size,
                   confirm_quit, background_color, debug, js_api, text_select, webview_ready):
-    app = QApplication.instance() or QApplication([])
+    global _app
+    _app = QApplication.instance() or QApplication([])
 
     def _create():
         browser = BrowserView(uid, title, url, width, height, resizable, fullscreen,
@@ -463,7 +467,7 @@ def create_window(uid, title, url, width, height, resizable, fullscreen, min_siz
 
     if uid == 'master':
         _create()
-        app.exec_()
+        _app.exec_()
     else:
         i = list(BrowserView.instances.values())[0] # arbitrary instance
         i.create_window_trigger.emit(_create)

--- a/webview/winforms.py
+++ b/webview/winforms.py
@@ -249,7 +249,7 @@ def create_window(uid, title, url, width, height, resizable, fullscreen, min_siz
         thread.Start()
         thread.Join()
     else:
-        i = list(BrowserView.instances.values())[0]     # arbitary instance
+        i = list(BrowserView.instances.values())[0]     # arbitrary instance
         i.Invoke(Func[Type](create))
 
 

--- a/webview/winforms.py
+++ b/webview/winforms.py
@@ -249,7 +249,8 @@ def create_window(uid, title, url, width, height, resizable, fullscreen, min_siz
         thread.Start()
         thread.Join()
     else:
-        BrowserView.instances['master'].Invoke(Func[Type](create))
+        i = list(BrowserView.instances.values())[0]     # arbitary instance
+        i.Invoke(Func[Type](create))
 
 
 def set_title(title, uid):


### PR DESCRIPTION
The master instance could have been closed when creating new windows, we
cannot rely on it to create the window for us. So we use an arbitary
running instance. This is the pattern followed for such scenarios on the
other platforms.

Closes #229, closes #230.