### PR TITLE
fix #232 : toggle_fullscreen doesn't work as expected

### DIFF
--- a/webview/winforms.py
+++ b/webview/winforms.py
@@ -197,13 +197,11 @@ class BrowserView:
 
         def toggle_fullscreen(self):
             screen = WinForms.Screen.FromControl(self)
-
             if not self.is_fullscreen:
                 self.old_size = self.Size
                 self.old_state = self.WindowState
                 self.old_style = self.FormBorderStyle
                 self.old_location = self.Location
-
 
                 self.TopMost = True
                 self.FormBorderStyle = 0  # FormBorderStyle.None

--- a/webview/winforms.py
+++ b/webview/winforms.py
@@ -196,13 +196,14 @@ class BrowserView:
             self.load_event.set()
 
         def toggle_fullscreen(self):
+            screen = WinForms.Screen.FromControl(self)
+
             if not self.is_fullscreen:
                 self.old_size = self.Size
                 self.old_state = self.WindowState
                 self.old_style = self.FormBorderStyle
                 self.old_location = self.Location
 
-                screen = WinForms.Screen.FromControl(self)
 
                 self.TopMost = True
                 self.FormBorderStyle = 0  # FormBorderStyle.None


### PR DESCRIPTION
a few days I had created an issues [toggle_fullscreen doesn't work as expected](https://github.com/r0x0r/pywebview/issues/232), and i had a try to fix this problem by myself. It seemed that no matter variable *self.is_fullscreen* is, variable *screen* is always expected to obtain