### PR TITLE
Set Window Size Functionality

### DIFF
--- a/tests/test_set_window_size.py
+++ b/tests/test_set_window_size.py
@@ -1,0 +1,14 @@
+import webview
+from .util import run_test
+
+
+def test_set_window_size():
+    run_test(main_func, set_window_size)
+
+
+def main_func():
+    webview.create_window('Set Window Size Test', 'https://www.example.org')
+
+
+def set_window_size():
+    webview.set_window_size(500, 500)

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -322,6 +322,17 @@ def toggle_fullscreen(uid='master'):
 
 
 @_api_call
+def set_window_size(width, height, uid='master'):
+    """
+    Set Window Size
+    :param width: desired width of target window
+    :param height: desired height of target window
+    :param uid: uid of the target instance
+    """
+    gui.set_window_size(width, height, uid)
+
+
+@_api_call
 def evaluate_js(script, uid='master'):
     """
     Evaluate given JavaScript code and return the result

--- a/webview/cocoa.py
+++ b/webview/cocoa.py
@@ -348,6 +348,21 @@ class BrowserView:
         AppHelper.callAfter(toggle)
         self.is_fullscreen = not self.is_fullscreen
 
+    def set_window_size(self, width, height):
+        def _set_window_size():
+            frame = self.window.frame()
+
+            # Keep the top left of the window in the same place
+            frame.origin.y += frame.size.height
+            frame.origin.y -= height
+
+            frame.size.width = width
+            frame.size.height = height
+
+            self.window.setFrame_display_(frame, True)
+
+        AppHelper.callAfter(_set_window_size)
+
     def get_current_url(self):
         def get():
             self._current_url = self.webkit.mainFrameURL()
@@ -639,6 +654,10 @@ def destroy_window(uid):
 
 def toggle_fullscreen(uid):
     BrowserView.instances[uid].toggle_fullscreen()
+
+
+def set_window_size(width, height, uid):
+    BrowserView.instances[uid].set_window_size(width, height)
 
 
 def get_current_url(uid):

--- a/webview/gtk.py
+++ b/webview/gtk.py
@@ -222,6 +222,9 @@ class BrowserView:
 
         self.is_fullscreen = not self.is_fullscreen
 
+    def set_window_size(self, width, height):
+        self.window.resize(width, height)
+
     def create_file_dialog(self, dialog_type, directory, allow_multiple, save_filename, file_types):
         if dialog_type == FOLDER_DIALOG:
             gtk_dialog_type = gtk.FileChooserAction.SELECT_FOLDER
@@ -360,6 +363,12 @@ def toggle_fullscreen(uid):
     def _toggle_fullscreen():
         BrowserView.instances[uid].toggle_fullscreen()
     glib.idle_add(_toggle_fullscreen)
+
+
+def set_window_size(width, height, uid):
+    def _set_window_size():
+        BrowserView.instances[uid].set_window_size(width,height)
+    glib.idle_add(_set_window_size)
 
 
 def get_current_url(uid):

--- a/webview/qt.py
+++ b/webview/qt.py
@@ -79,6 +79,7 @@ class BrowserView(QMainWindow):
     dialog_trigger = QtCore.pyqtSignal(int, str, bool, str, str)
     destroy_trigger = QtCore.pyqtSignal()
     fullscreen_trigger = QtCore.pyqtSignal()
+    window_size_trigger = QtCore.pyqtSignal(int, int)
     current_url_trigger = QtCore.pyqtSignal()
     evaluate_js_trigger = QtCore.pyqtSignal(str, str)
 
@@ -226,6 +227,7 @@ class BrowserView(QMainWindow):
         self.dialog_trigger.connect(self.on_file_dialog)
         self.destroy_trigger.connect(self.on_destroy_window)
         self.fullscreen_trigger.connect(self.on_fullscreen)
+        self.window_size_trigger.connect(self.on_window_size)
         self.current_url_trigger.connect(self.on_current_url)
         self.evaluate_js_trigger.connect(self.on_evaluate_js)
         self.set_title_trigger.connect(self.on_set_title)
@@ -306,6 +308,9 @@ class BrowserView(QMainWindow):
 
         self.is_fullscreen = not self.is_fullscreen
 
+    def on_window_size(self, width, height):
+        self.setFixedSize(width, height)
+
     def on_evaluate_js(self, script, uuid):
         def return_result(result):
             result = BrowserView._convert_string(result)
@@ -385,6 +390,9 @@ class BrowserView(QMainWindow):
 
     def toggle_fullscreen(self):
         self.fullscreen_trigger.emit()
+
+    def set_window_size(self, width, height):
+        self.window_size_trigger.emit(width, height)
 
     def evaluate_js(self, script):
         self.load_event.wait()
@@ -497,6 +505,8 @@ def destroy_window(uid):
 def toggle_fullscreen(uid):
     BrowserView.instances[uid].toggle_fullscreen()
 
+def set_window_size(width, height, uid):
+    BrowserView.instances[uid].set_window_size(width, height)
 
 def create_file_dialog(dialog_type, directory, allow_multiple, save_filename, file_types):
     # Create a file filter by parsing allowed file types

--- a/webview/win32.py
+++ b/webview/win32.py
@@ -194,6 +194,12 @@ class BrowserView(object):
     def destroy(self):
         win32gui.SendMessage(self.hwnd, win32con.WM_DESTROY)
 
+    def set_window_size(self, width, height):
+        self.width = width
+        self.height = height
+        win32gui.SetWindowPos(self.hwnd, win32con.HWND_TOP, self.pos_x, self.pos_y, width, height,
+                              win32con.SWP_SHOWWINDOW)
+
     def load_url(self, url):
         self.url = url
         self.browser.Navigate2(url)
@@ -318,6 +324,10 @@ def destroy_window(uid):
 
 def toggle_fullscreen(uid):
     BrowserView.instance.toggle_fullscreen()
+
+
+def set_window_size(width, height, uid):
+    BrowserView.instance.set_window_size(width, height)
 
 
 def evaluate_js(script, uid):

--- a/webview/winforms.py
+++ b/webview/winforms.py
@@ -222,6 +222,10 @@ class BrowserView:
                 self.Location = self.old_location
                 self.is_fullscreen = False
 
+        def set_window_size(self, width, height):
+            windll.user32.SetWindowPos(self.Handle.ToInt32(), None, self.Location.X, self.Location.Y,
+                width, height, 64)
+
 
 def create_window(uid, title, url, width, height, resizable, fullscreen, min_size,
                   confirm_quit, background_color, debug, js_api, text_select, webview_ready):
@@ -359,6 +363,11 @@ def load_html(content, base_uri, uid):
 def toggle_fullscreen(uid):
     window = BrowserView.instances[uid]
     window.toggle_fullscreen()
+
+
+def set_window_size(width, height, uid):
+    window = BrowserView.instances[uid]
+    window.set_window_size(width, height)
 
 
 def destroy_window(uid):


### PR DESCRIPTION
Added set_window_size to api.
Added for all backends, tested on two of them

```
set_window_size(width, height, uid='master')
```

Tested Platforms:
- cocoa
- winforms

Untested platforms:
- win32
- gtk
- Qt

I wasn't able to test the win32, qtk, and Qt, so if someone wants to test those that would be great. 
