### PR TITLE
Show the default window control buttons.

### DIFF
--- a/webview/cocoa.py
+++ b/webview/cocoa.py
@@ -345,11 +345,6 @@ class BrowserView:
             self.window.setTitlebarAppearsTransparent_(True)
             self.window.setTitleVisibility_(NSWindowTitleHidden)
 
-            # Hide standard buttons
-            self.window.standardWindowButton_(AppKit.NSWindowCloseButton).setHidden_(True)
-            self.window.standardWindowButton_(AppKit.NSWindowMiniaturizeButton).setHidden_(True)
-            self.window.standardWindowButton_(AppKit.NSWindowZoomButton).setHidden_(True)
-
         else:
             # Set the titlebar color (so that it does not change with the window color)
             self.window.contentView().superview().subviews().lastObject().setBackgroundColor_(AppKit.NSColor.windowBackgroundColor())


### PR DESCRIPTION
It seems pretty user-unfriendly to remove these. This matches (most?) other frameless MacOS apps (Slack, Standard Notes, etc).

Could also make this an option (`window_controls=True`)?
