### PR TITLE
Use os.remove rather than shutil.rmtree to remove error.log on exit

### DIFF
--- a/webview/cef.py
+++ b/webview/cef.py
@@ -252,7 +252,7 @@ def shutdown():
             shutil.rmtree('webrtc_event_logs')
 
         if os.path.exists('error.log'):
-            shutil.rmtree('error.log')
+            os.remove('error.log')
 
     except Exception as e:
         logger.debug(e, exc_info=True)


### PR DESCRIPTION
shutil.rmtree is only supposed to take a directory argument according
to docs. Was resulting in an exception on window shutdown.