### PR TITLE
Fixed typo

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -165,7 +165,7 @@ Change the title of the window.
 ## toggle_fullscreen
 
 ``` python
-togle_fullscreen()
+toggle_fullscreen()
 ```
 
 Toggle fullscreen mode on the active monitor.


### PR DESCRIPTION
Fixed typo for 'togle_fullscreen()' to 'toggle_fullscreen()'.