### PR TITLE
Fix for pytest warning about invalid escape sequence

### DIFF
--- a/webview/util.py
+++ b/webview/util.py
@@ -135,7 +135,7 @@ def escape_line_breaks(string):
 
 
 def inject_base_uri(content, base_uri):
-    pattern = '<%s(?:[\s]+[^>]*|)>'
+    pattern = r'<%s(?:[\s]+[^>]*|)>'
     base_tag = '<base href="%s">' % base_uri
 
     match = re.search(pattern % 'base', content)


### PR DESCRIPTION
pytest throws a warning in util.py (you only see it if pytest results are not cached and/or you make a change to the file):

webview/util.py:138
  .../pywebview/webview/util.py:138: DeprecationWarning: invalid escape sequence \s
    pattern = '<%s(?:[\s]+[^>]*|)>'

This pull request marks pattern literal as raw string, which avoids the warning.