### PR TITLE
Don't escape line breaks in result of js_bridge_call

### DIFF
--- a/webview/js/api.py
+++ b/webview/js/api.py
@@ -46,7 +46,7 @@ window.pywebview = {
             if (returnObj.isSet) {
                 returnObj.isSet = false;
                 try {
-                    resolve(JSON.parse(returnObj.value.replace(/\\n/, '\\\\n')));
+                    resolve(JSON.parse(returnObj.value));
                 } catch(e) {
                     resolve(returnObj.value);
                 }

--- a/webview/util.py
+++ b/webview/util.py
@@ -86,7 +86,7 @@ def parse_api_js(api_instance, platform):
 def js_bridge_call(window, func_name, param):
     def _call():
         result = json.dumps(func(func_params))
-        code = 'window.pywebview._returnValues["{0}"] = {{ isSet: true, value: {1}}}'.format(func_name, escape_line_breaks(result))
+        code = 'window.pywebview._returnValues["{0}"] = {{ isSet: true, value: {1}}}'.format(func_name, result)
         window.evaluate_js(code)
 
     func = getattr(window.js_api, func_name, None)


### PR DESCRIPTION
Escaping line breaks in results of the python calls causes problems when result object contains strings with line breaks. What you get on js side is strings with '\n' as literal strings (a slash followed by letter n) instead of the special new-line character. This basically mangles the data being passed from python to js in an unrecoverable manner: js code has no way of knowing if it was meant to be the literal text or a special character.

json.dumps() already escapes everything that needs to be escaped and creates a valid string to be passed to the js side. JSON.parse() correctly reverses the data to it's original state. I don't think there is a need to mess with special characters here. 