### PR TITLE
Workaround for segmentation fault on closing the main window with Qt

### DIFF
--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -295,6 +295,7 @@ class BrowserView(QMainWindow):
             pass
 
         if len(BrowserView.instances) == 0:
+            self.hide()
             _app.exit()
 
     def on_destroy_window(self):


### PR DESCRIPTION
Running on Ubuntu 19.04 with PyQt5 5.13.0. When I close the main window I get a segmentation fault (tested it on multiple machines). You can easily recreate the problem with 

`PYWEBVIEW_GUI=qt
python examples/simple_browser.py`

When you close the window (via x in the top right corner) you will see 'Segmentation fault (core dumped)' in the terminal.

It maybe a Qt bug, but it prevents the execution of any code after webview.start() since python crashes hard. I found that hiding the main window before _app.exit() avoids the segfault. 

It's a workaround (not a fix). 

P.S. If an inspector window is open when you close main window, you get segfault even with this workaround.
