### PR TITLE
Update guilib.py

### DIFF
--- a/webview/guilib.py
+++ b/webview/guilib.py
@@ -84,7 +84,7 @@ def initialize(forced_gui=None):
             raise WebViewException('You must have either PyObjC (for Cocoa support) or Qt with Python bindings installed in order to use pywebview.')
 
     elif platform.system() == 'Linux' or platform.system() == 'OpenBSD':
-        if forced_gui== 'gtk' or forced_gui != 'qt':
+        if forced_gui != 'qt':
             guis = [import_gtk, import_qt]
         else:
             guis = [import_qt, import_gtk]

--- a/webview/guilib.py
+++ b/webview/guilib.py
@@ -84,10 +84,10 @@ def initialize(forced_gui=None):
             raise WebViewException('You must have either PyObjC (for Cocoa support) or Qt with Python bindings installed in order to use pywebview.')
 
     elif platform.system() == 'Linux' or platform.system() == 'OpenBSD':
-        if forced_gui != 'qt':
-            guis = [import_gtk, import_qt]
-        else:
+        if forced_gui == 'qt':
             guis = [import_qt, import_gtk]
+        else:
+            guis = [import_gtk, import_qt]
 
         if not try_import(guis):
             raise WebViewException('You must have either QT or GTK with Python extensions installed in order to use pywebview.')


### PR DESCRIPTION
if `forced_gui == 'gtk'` then  `forced_gui != 'qt'` so it is redundant here, we can remove it.