### PR TITLE
[WIP] add move function

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -427,6 +427,21 @@ class BrowserView:
 
         AppHelper.callAfter(_set_window_size)
 
+    def move(self, x, y):
+        def _move():
+            frame = self.window.frame()
+
+            screenFrame = AppKit.NSScreen.mainScreen().frame()
+            if screenFrame is None:
+                raise RuntimeError('Failed to obtain screen')
+
+            frame.origin.x = x
+            frame.origin.y = screenFrame.size.height - frame.size.height - y
+
+            self.window.setFrame_display_(frame, True)
+
+        AppHelper.callAfter(_move)
+
     def get_current_url(self):
         def get():
             self._current_url = str(self.webkit.URL())
@@ -751,6 +766,10 @@ def toggle_fullscreen(uid):
 
 def set_window_size(width, height, uid):
     BrowserView.instances[uid].set_window_size(width, height)
+
+
+def move(x, y, uid):
+    BrowserView.instances[uid].move(x, y)
 
 
 def get_current_url(uid):

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -245,6 +245,9 @@ class BrowserView:
     def set_window_size(self, width, height):
         self.window.resize(width, height)
 
+    def move(self, x, y):
+        self.window.move(x, y)
+
     def create_file_dialog(self, dialog_type, directory, allow_multiple, save_filename, file_types):
         if dialog_type == FOLDER_DIALOG:
             gtk_dialog_type = gtk.FileChooserAction.SELECT_FOLDER
@@ -398,6 +401,12 @@ def set_window_size(width, height, uid):
     def _set_window_size():
         BrowserView.instances[uid].set_window_size(width,height)
     glib.idle_add(_set_window_size)
+
+
+def move(x, y, uid):
+    def _set_window_position():
+        BrowserView.instances[uid].set_window_position(x, y)
+    glib.idle_add(_set_window_position)
 
 
 def get_current_url(uid):

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -55,6 +55,7 @@ class BrowserView(QMainWindow):
     destroy_trigger = QtCore.pyqtSignal()
     fullscreen_trigger = QtCore.pyqtSignal()
     window_size_trigger = QtCore.pyqtSignal(int, int)
+    window_move_trigger = QtCore.pyqtSignal(int, int)
     current_url_trigger = QtCore.pyqtSignal()
     evaluate_js_trigger = QtCore.pyqtSignal(str, str)
 
@@ -220,6 +221,7 @@ class BrowserView(QMainWindow):
         self.destroy_trigger.connect(self.on_destroy_window)
         self.fullscreen_trigger.connect(self.on_fullscreen)
         self.window_size_trigger.connect(self.on_window_size)
+        self.window_move_trigger.connect(self.on_window_move)
         self.current_url_trigger.connect(self.on_current_url)
         self.evaluate_js_trigger.connect(self.on_evaluate_js)
         self.set_title_trigger.connect(self.on_set_title)
@@ -312,6 +314,9 @@ class BrowserView(QMainWindow):
     def on_window_size(self, width, height):
         self.setFixedSize(width, height)
 
+    def on_window_move(self, x, y):
+        self.move(x, y)
+
     def on_evaluate_js(self, script, uuid):
         def return_result(result):
             result = BrowserView._convert_string(result)
@@ -384,6 +389,9 @@ class BrowserView(QMainWindow):
 
     def set_window_size(self, width, height):
         self.window_size_trigger.emit(width, height)
+
+    def move(self, x, y):
+        self.window_move_trigger.emit(x, y)
 
     def evaluate_js(self, script):
         self.loaded.wait()
@@ -493,6 +501,10 @@ def toggle_fullscreen(uid):
 
 def set_window_size(width, height, uid):
     BrowserView.instances[uid].set_window_size(width, height)
+
+
+def move(x, y, uid):
+    BrowserView.instances[uid].move(x, y)
 
 
 def create_file_dialog(dialog_type, directory, allow_multiple, save_filename, file_types, uid):

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -469,6 +469,13 @@ class BrowserView:
             windll.user32.SetWindowPos(self.Handle.ToInt32(), None, self.Location.X, self.Location.Y,
                 width, height, 64)
 
+        def move(self, x, y):
+            SWP_NOSIZE = 0x0001  # Retains the current size
+            SWP_NOZORDER = 0x0004  # Retains the current Z order 
+            SWP_SHOWWINDOW = 0x0040  # Displays the window
+            windll.user32.SetWindowPos(self.Handle.ToInt32(), None, x, y, None, None,
+                                       SWP_NOSIZE|SWP_NOZORDER|SWP_SHOWWINDOW)
+
     @staticmethod
     def alert(message):
         WinForms.MessageBox.Show(message)
@@ -711,6 +718,11 @@ def toggle_fullscreen(uid):
 def set_window_size(width, height, uid):
     window = BrowserView.instances[uid]
     window.set_window_size(width, height)
+
+
+def move(x, y, uid):
+    window = BrowserView.instances[uid]
+    window.move(x, y)
 
 
 def destroy_window(uid):

--- a/webview/window.py
+++ b/webview/window.py
@@ -155,6 +155,15 @@ class Window:
         """
         self.gui.set_window_size(width, height, self.uid)
 
+    @_shown_call
+    def move(self, x, y):
+        """
+        Move Window
+        :param x: desired x coordinate of target window
+        :param y: desired y coordinate of target window
+        """
+        self.gui.move(x, y, self.uid)
+
     @_loaded_call
     def evaluate_js(self, script):
         """


### PR DESCRIPTION
partially tackles #351 adding a `window.set_window_position(x, y)` implemented **only for gtk and qt** platforms, sorry, I am not a Mac or Windows and have no experience with `cocoa` or `winforms`.
Leaving here as base for someone else to implement the rest of platforms :)