### PR TITLE
Add missing dependency for GTK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 extras_require = {
     'qt': ['PyQt5', 'pyqtwebengine'],
     'cef': ['cefpython3'],
+    'gtk': ['PyGObject'],
 }
 
 install_requires = [


### PR DESCRIPTION
Without this package, loading gtk fails with:
[pywebview] GTK cannot be loaded
Traceback (most recent call last):
  File "/home/dan/Documents/pywebview_ws/pywebview/webview/guilib.py", line 16, in import_gtk
    import webview.platforms.gtk as guilib
  File "/home/dan/Documents/pywebview_ws/pywebview/webview/platforms/gtk.py", line 25, in <module>
    import gi
ModuleNotFoundError: No module named 'gi'
