### PR TITLE
Changed platform-loading logic

### DIFF
--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -77,6 +77,7 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
         raise WebViewException('You must create a window first before calling this function.')
 
     guilib = initialize(gui)
+    logging.info('using gui '+guilib.renderer)
 
     # thanks to the buggy EdgeHTML, http server must be used for local urls
     if guilib.renderer == 'edgehtml':

--- a/webview/guilib.py
+++ b/webview/guilib.py
@@ -35,7 +35,11 @@ def initialize(gui=None):
     errors = []
     for a_gui in guis:
         try:
-            guilib = importlib.import_module('webview.platforms.' + a_gui)
+            if a_gui == 'cef' and platform.system == 'Windows':
+                import webview.platforms.winforms as guilib
+                guilib.use_cef()
+            else:
+                guilib = importlib.import_module('webview.platforms.' + a_gui)
         except Exception as e:
             errors.append(str(e))
         if guilib is not None:

--- a/webview/guilib.py
+++ b/webview/guilib.py
@@ -28,6 +28,8 @@ def initialize(gui=None):
         guis = ['cocoa', 'qt']
     elif platform.system() == 'Windows':
         guis = ['winforms']
+    elif 'KDE_FULL_SESSION' in os.environ:
+        guis = ['qt', 'gtk']
     else:
         guis = ['gtk', 'qt']
 


### PR DESCRIPTION
1. Use importlib.import_module instead of nearly identical import statements.
2. Allow passing a list instead of just one string, to fully customize the order that we try guis.
3. ~~Remove confusing logic to ignore gtk if envvar KDE_FULL_SESSION is set.~~