### PR TITLE
Support python2.7: change getfullargspec() to getargspec()

### DIFF
--- a/webview/util.py
+++ b/webview/util.py
@@ -75,7 +75,7 @@ def parse_file_type(file_type):
 
 def parse_api_js(window, platform, uid=''):
     def get_args(f):
-        return list(inspect.getfullargspec(f).args)
+        return list(inspect.getargspec(f).args)
 
     def generate_func():
         if window._js_api:

--- a/webview/util.py
+++ b/webview/util.py
@@ -75,7 +75,11 @@ def parse_file_type(file_type):
 
 def parse_api_js(window, platform, uid=''):
     def get_args(f):
-        return list(inspect.getargspec(f).args)
+        try:
+            params = list(inspect.getfullargspec(f).args) # Python 3
+        except AttributeError:
+            params = list(inspect.getargspec(f).args)  # Python 2
+        return params
 
     def generate_func():
         if window._js_api:

--- a/webview/window.py
+++ b/webview/window.py
@@ -299,6 +299,7 @@ class Window:
         for func in functions:
             name = func.__name__
             self._functions[name] = func
+            
             try:
                 params = list(inspect.getfullargspec(func).args) # Python 3
             except AttributeError:

--- a/webview/window.py
+++ b/webview/window.py
@@ -299,8 +299,11 @@ class Window:
         for func in functions:
             name = func.__name__
             self._functions[name] = func
-
-            params = list(inspect.getargspec(func).args)
+            try:
+                params = list(inspect.getfullargspec(func).args) # Python 3
+            except AttributeError:
+                params = list(inspect.getargspec(func).args)  # Python 2
+            
 
             func_list.append({
                 'func': name,

--- a/webview/window.py
+++ b/webview/window.py
@@ -300,7 +300,7 @@ class Window:
             name = func.__name__
             self._functions[name] = func
 
-            params = list(inspect.getfullargspec(func).args)
+            params = list(inspect.getargspec(func).args)
 
             func_list.append({
                 'func': name,


### PR DESCRIPTION
In order to support python2.7 change getfullargspec() to getargspec().