### PR TITLE
Fixed typo in pip command

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -18,7 +18,7 @@ cd pywebview
 ``` bash
 virtualenv -p python3 venv
 source venv/bin/activate
-pip intall -e .
+pip install -e .
 pip install pytest
 ```
 


### PR DESCRIPTION
"Create a virtual environment" had a letter missing from "install" in the line "pip install -e ."