### PR TITLE
added topmost and toggle_topmost, for Windows.

### DIFF
--- a/docs/examples/toggle_topmost.md
+++ b/docs/examples/toggle_topmost.md
@@ -1,0 +1,19 @@
+# Toggle topmost
+
+Switch application window to topmost mode after five seconds (window stays on top of, or in front of, other windows).
+
+``` python
+import webview
+import time
+
+def toggle_topmost(window):
+    # wait a few seconds before toggling topmost:
+    time.sleep(5)
+
+    window.toggle_topmost()
+
+
+if __name__ == '__main__':
+    window = webview.create_window('Topmost window', 'https://pywebview.flowrl.com/hello')
+    webview.start(window)
+```

--- a/docs/examples/topmost.md
+++ b/docs/examples/topmost.md
@@ -1,0 +1,14 @@
+# Topmost window
+
+Create a window that stays on top of, or in front of, other windows.
+
+``` python
+import webview
+
+
+if __name__ == '__main__':
+    webview.create_window('Topmost window',
+                          'https://pywebview.flowrl.com/hello',
+                          topmost=True)
+    webview.start()
+```

--- a/examples/toggle_topmost.py
+++ b/examples/toggle_topmost.py
@@ -1,0 +1,18 @@
+import webview
+import time
+
+"""
+This example demonstrates how to toggle topmost mode programmatically.
+"""
+
+
+def toggle_topmost(window):
+    # wait a few seconds before toggle topmost:
+    time.sleep(5)
+
+    window.toggle_topmost()
+
+
+if __name__ == '__main__':
+    window = webview.create_window('Topmost window', 'https://pywebview.flowrl.com/hello')
+    webview.start(toggle_topmost, window)

--- a/examples/topmost.py
+++ b/examples/topmost.py
@@ -1,0 +1,12 @@
+import webview
+
+"""
+This example demonstrates how to create a topmost webview window.
+"""
+
+if __name__ == '__main__':
+    # Create webview window that stays on top of, or in front of, all other windows
+    webview.create_window('Topmost window',
+                          'https://pywebview.flowrl.com/hello',
+                          topmost=True)
+    webview.start()

--- a/tests/test_toggle_topmost.py
+++ b/tests/test_toggle_topmost.py
@@ -1,0 +1,14 @@
+import webview
+from .util import run_test
+
+
+def test_toggle_topmost():
+    window = webview.create_window("Toggle topmost test", "https://www.example.org")
+    run_test(webview, window, toggle_topmost)
+
+
+def toggle_topmost(window):
+    try:
+        window.toggle_topmost()
+    except NotImplementedError:
+        print('This OS/guilib does not yet have "topmost" feature.')

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -103,7 +103,8 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
 
 def create_window(title, url=None, html=None, js_api=None, width=800, height=600, x=None, y=None,
                   resizable=True, fullscreen=False, min_size=(200, 100), hidden=False, frameless=False,
-                  minimized=False, confirm_close=False, background_color='#FFFFFF', text_select=False):
+                  minimized=False, topmost=False, confirm_close=False, background_color='#FFFFFF',
+                  text_select=False):
     """
     Create a web view window using a native GUI. The execution blocks after this function is invoked, so other
     program logic must be executed in a separate thread.
@@ -117,6 +118,7 @@ def create_window(title, url=None, html=None, js_api=None, width=800, height=600
     :param hidden: Whether the window should be hidden.
     :param frameless: Whether the window should have a frame.
     :param minimized: Display window minimized
+    :param topmost: Keep window above other windows (required OS: Windows)
     :param confirm_close: Display a window close confirmation dialog. Default is False
     :param background_color: Background color as a hex string that is displayed before the content of webview is loaded. Default is white.
     :param text_select: Allow text selection on page. Default is False.
@@ -131,7 +133,8 @@ def create_window(title, url=None, html=None, js_api=None, width=800, height=600
 
     window = Window(uid, make_unicode(title), transform_url(url), html,
                     width, height, x, y, resizable, fullscreen, min_size, hidden, frameless,
-                    minimized, confirm_close, background_color, js_api, text_select)
+                    minimized, topmost, confirm_close, background_color, js_api,
+                    text_select)
     windows.append(window)
 
     if threading.current_thread().name != 'MainThread' and guilib:

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -801,6 +801,10 @@ def toggle_fullscreen(uid):
     BrowserView.instances[uid].toggle_fullscreen()
 
 
+def toggle_topmost(uid):
+    raise NotImplementedError('toggle_topmost is not yet implemented for cocoa.')
+
+
 def resize(width, height, uid):
     BrowserView.instances[uid].resize(width, height)
 

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -414,6 +414,12 @@ def toggle_fullscreen(uid):
     glib.idle_add(_toggle_fullscreen)
 
 
+def toggle_topmost(uid):
+    def _toggle_topmost():
+        raise NotImplementedError('toggle_topmost is not yet implemented for gtk.')
+    glib.idle_add(_toggle_topmost)
+
+
 def resize(width, height, uid):
     def _resize():
         BrowserView.instances[uid].resize(width,height)

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -602,6 +602,10 @@ def toggle_fullscreen(uid):
     BrowserView.instances[uid].toggle_fullscreen()
 
 
+def toggle_topmost(uid):
+    raise NotImplementedError('toggle_topmost is not yet implemented for qt.')
+
+
 def resize(width, height, uid):
     BrowserView.instances[uid].resize_(width, height)
 

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -379,6 +379,10 @@ class BrowserView:
                 self.frameless = window.frameless
                 self.FormBorderStyle = 0
 
+            self.is_topmost = False
+            if window.topmost:
+                self.toggle_topmost()
+
             if is_cef:
                 CEF.create_browser(window, self.Handle.ToInt32(), BrowserView.alert)
             elif is_edge:
@@ -485,6 +489,18 @@ class BrowserView:
                     self.FormBorderStyle = self.old_style
                     self.Location = self.old_location
                     self.is_fullscreen = False
+
+            if self.InvokeRequired:
+                self.Invoke(Func[Type](_toggle))
+            else:
+                _toggle()
+
+        def toggle_topmost(self):
+            def _toggle():
+                if not self.is_topmost:
+                    self.TopMost = True
+                else:
+                    self.TopMost = False
 
             if self.InvokeRequired:
                 self.Invoke(Func[Type](_toggle))
@@ -765,6 +781,11 @@ def hide(uid):
 def toggle_fullscreen(uid):
     window = BrowserView.instances[uid]
     window.toggle_fullscreen()
+
+
+def toggle_topmost(uid):
+    window = BrowserView.instances[uid]
+    window.toggle_topmost()
 
 
 def resize(width, height, uid):

--- a/webview/window.py
+++ b/webview/window.py
@@ -45,8 +45,8 @@ def _loaded_call(function):
 
 class Window:
     def __init__(self, uid, title, url, html, width, height, x, y, resizable, fullscreen,
-                 min_size, hidden, frameless, minimized, confirm_close, background_color,
-                 js_api, text_select):
+                 min_size, hidden, frameless, minimized, topmost, confirm_close,
+                 background_color, js_api, text_select):
         self.uid = uid
         self.title = make_unicode(title)
         self.url = None if html else transform_url(url)
@@ -64,6 +64,7 @@ class Window:
         self.frameless = frameless
         self.hidden = hidden
         self.minimized = minimized
+        self.topmost = topmost
 
         self._js_api = js_api
         self._functions = {}
@@ -247,6 +248,13 @@ class Window:
         Toggle fullscreen mode
         """
         self.gui.toggle_fullscreen(self.uid)
+
+    @_shown_call
+    def toggle_topmost(self):
+        """
+        Toggle topmost mode
+        """
+        self.gui.toggle_topmost(self.uid)
 
     @_shown_call
     def move(self, x, y):


### PR DESCRIPTION
Closes #476 

Added examples, updated docs, added a trivial test that things don't error out.

Tested on my Windows machine that starting a webview window with topmost=True does in fact keep that window above others.