### PR TITLE
Internal Server Revamp

### DIFF
--- a/webview/http_server.py
+++ b/webview/http_server.py
@@ -1,25 +1,13 @@
-import webview
 import os
-import sys
+import logging
+from random import random
 import socket
 import threading
-import logging
+import wsgiref.simple_server
 
-from random import random
-
-try:
-    from BaseHTTPServer import HTTPServer
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
-    from SocketServer import ThreadingMixIn
-except ImportError:
-    from http.server import SimpleHTTPRequestHandler, HTTPServer
-    from socketserver import ThreadingMixIn
-
-from webview.util import base_uri
 
 logger = logging.getLogger('pywebview')
 
-port = None
 
 def _get_random_port():
     def random_port():
@@ -28,62 +16,28 @@ def _get_random_port():
 
         try:
             sock.bind(('localhost', port))
-            result = port
-        except:
-            result = None
+        except OSError:
             logger.warning('Port %s is in use' % port)
+            return None
+        else:
+            return port
         finally:
             sock.close()
 
-        return result
-
-    port = random_port()
-    while not port:
-        port = random_port()
-
-    return port
-
-
-class HTTPHandler(SimpleHTTPRequestHandler):
-    def translate_path(self, path):
-        path = SimpleHTTPRequestHandler.translate_path(self, path)
-        relpath = os.path.relpath(path, os.getcwd())
-        fullpath = os.path.join(self.server.base_path, relpath)
-        return fullpath
-
-    def log_message(self, format, *args):
-        if os.environ.get('PYWEBVIEW_LOG') == 'debug':
-            super(HTTPHandler, self).log_message(format, *args)
-
-
-class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
-    """Handle requests in a separate thread."""
+    for port in iter(random_port, ...):
+        if port is not None:
+            return port
 
 
 def start_server(url):
-    def _start(httpd):
-        try:
-            httpd.serve_forever()
-        except Exception as e:
-            logger.exception(e)
-
-    global port
-
-    base_path = os.path.dirname(url.replace('file://', ''))
-    if not os.path.exists(base_path):
-        raise IOError('Directory %s is not found' % base_path)
-
     port = _get_random_port()
-    server_address = ('localhost', port)
+    server = wsgiref.simple_server.make_server('localhost', port, wsgiref.simple_server.demo_app)
 
-    httpd = ThreadedHTTPServer(server_address, HTTPHandler)
-    httpd.base_path = base_path
-
-    t = threading.Thread(target=_start, args=(httpd,))
+    t = threading.Thread(target=server.serve_forever)
     t.daemon = True
     t.start()
 
     new_url = 'http://localhost:{0}/{1}'.format(port, os.path.basename(url))
     logger.debug('HTTP server started on http://localhost:{0}'.format(port))
 
-    return new_url, httpd
+    return new_url

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -284,7 +284,7 @@ class BrowserView:
             if self.httpd:
                 self.httpd.shutdown()
 
-            url, _ = start_server('file://' + self.temp_html)
+            url = start_server('file://' + self.temp_html)
             self.ishtml = True
             self.web_view.Navigate(url)
 

--- a/webview/window.py
+++ b/webview/window.py
@@ -75,7 +75,6 @@ class Window:
         self.shown = Event()
 
         self.gui = None
-        self._httpd = None
         self._is_http_server = False
 
     def _initialize(self, gui, multiprocessing, http_server):
@@ -83,9 +82,9 @@ class Window:
         self.loaded._initialize(multiprocessing)
         self.shown._initialize(multiprocessing)
         self._is_http_server = http_server
-
+        
         if http_server and self.url and self.url.startswith('file://'):
-            self.url, self._httpd = start_server(self.url)
+            self.url = start_server(self.url)
 
     @property
     def width(self):
@@ -152,14 +151,10 @@ class Window:
         :param url: url to load
         :param uid: uid of the target instance
         """
-        if self._httpd:
-            self._httpd.shutdown()
-            self._httpd = None
-
         url = transform_url(url)
 
         if (self._is_http_server or self.gui.renderer == 'edgehtml') and url.startswith('file://'):
-            url, self._httpd = start_server(url)
+            url = start_server(url)
 
         self.gui.load_url(url, self.uid)
 
@@ -172,9 +167,6 @@ class Window:
         :param base_uri: Base URI for resolving links. Default is the directory of the application entry point.
         :param uid: uid of the target instance
         """
-
-        if self._httpd:
-            self._httpd.shutdown()
 
         content = make_unicode(content)
         self.gui.load_html(content, base_uri, self.uid)


### PR DESCRIPTION
Rewrites the internal server to be wsgi-based, dramatically improving backend support.

This also includes features for handling static files and URL routing.

Closes #483

This uses [`wsgiref.simple_server`](https://docs.python.org/3/library/wsgiref.html#module-wsgiref.simple_server), which is based on `http.server`. While this isn't secure or terribly performant, it is simple and is probably good enough for single-user local stuff (ie this use case).

The interface I'm going with is that you may pass a WSGI app (which includes the included static and routing options) any place the public API expects a URL, and pywebview will manage it. (Of course, the user can elect to manage the server themselves and pass a URL to pywebview.)

This means that the user isn't required to mess with ports and threading and stuff. So using an existing wsgi-compatible application could be as simple as:

```python
import webview
import myapp.wsgi

webview.create_window('test', myapp.wsgi.app)
webview.start()
```