### PR TITLE
Fixes arrow keys not responding in text input fields.

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -261,6 +261,13 @@ class BrowserView:
             :return:
             """
 
+            # Fix arrow keys not responding in text inputs
+            keyCode_ = theEvent.keyCode()
+            UP, DOWN, LEFT, RIGHT = 126, 125, 123, 124
+
+            if keyCode_ in (UP, DOWN, LEFT, RIGHT):
+                return False
+            
             if theEvent.type() == AppKit.NSKeyDown and theEvent.modifierFlags() & AppKit.NSCommandKeyMask:
                 responder = self.window().firstResponder()
                 keyCode = theEvent.keyCode()


### PR DESCRIPTION
Quick fix to make up down left and right work on OSX.  To see if you have this problem, try moving left and right in the text box of the todos example. 