### PR TITLE
Fix AttributeError when called with html arg

### DIFF
--- a/webview/window.py
+++ b/webview/window.py
@@ -87,7 +87,14 @@ class Window:
         self._is_http_server = http_server
 
         # WebViewControl as of 5.1.1 crashes on file:// urls. Stupid workaround to make it work
-        if gui.renderer == "edgehtml" and (self.original_url.startswith('file://') or '://' not in self.original_url):
+        if (
+            gui.renderer == "edgehtml"
+            and self.original_url is not None
+            and (
+                self.original_url.startswith("file://")
+                or "://" not in self.original_url
+            )
+        ):
             self._is_http_server = True
 
         self.real_url = resolve_url(self.original_url, self._is_http_server)


### PR DESCRIPTION
`self.original_url` is None when `create_window` is called with the `html` argument.

Because of that this check would raise an AttributeError when it tried to call 
`startswith` on `self.original_url`.