### PR TITLE
Only expose class instance methods as functions for the js API

### DIFF
--- a/tests/test_js_api.py
+++ b/tests/test_js_api.py
@@ -22,6 +22,9 @@ def test_concurrent():
 
 
 class Api:
+    class ApiTestException(Exception):
+        pass
+
     def get_int(self):
         return 420
 
@@ -44,7 +47,7 @@ class Api:
         return 'te"st'
 
     def raise_exception(self):
-        raise Exception()
+        raise Api.ApiTestException()
 
     def echo(self, param):
         return param

--- a/webview/util.py
+++ b/webview/util.py
@@ -108,7 +108,7 @@ def parse_api_js(window, platform, uid=''):
 
     def generate_func():
         if window._js_api:
-            functions = { name: get_args(getattr(window._js_api, name))[1:] for name in dir(window._js_api) if callable(getattr(window._js_api, name)) and not name.startswith('_')}
+            functions = { name: get_args(getattr(window._js_api, name))[1:] for name in dir(window._js_api) if inspect.ismethod(getattr(window._js_api, name)) and not name.startswith('_')}
         else:
             functions = {}
 

--- a/webview/util.py
+++ b/webview/util.py
@@ -126,6 +126,7 @@ def parse_api_js(window, platform, uid=''):
         func_list = generate_func()
     except Exception as e:
         logger.exception(e)
+        func_list = []
 
     js_code = npo.src + event.src + api.src % (_token, platform, uid, func_list) + dom.src + drag.src % webview.DRAG_REGION_SELECTOR
     return js_code


### PR DESCRIPTION
This fixes issue #629 by making it so that we only pick up attributes that are instance methods.