### PR TITLE
Fix KDE_FULL_SESSION not being used

### DIFF
--- a/webview/guilib.py
+++ b/webview/guilib.py
@@ -70,7 +70,7 @@ def initialize(forced_gui=None):
         forced_gui = 'qt' if 'KDE_FULL_SESSION' in os.environ else None
         forced_gui = os.environ['PYWEBVIEW_GUI'].lower() \
             if 'PYWEBVIEW_GUI' in os.environ and os.environ['PYWEBVIEW_GUI'].lower() in ['qt', 'gtk', 'cef', 'mshtml', 'edgechromium', 'edgehtml'] \
-            else None
+            else forced_gui
 
     forced_gui_ = forced_gui
 


### PR DESCRIPTION
I noticed that the variable `KDE_FULL_SESSION` was being overridden. This simple change ensures that those in a KDE desktop environment will default to qt, and the order of preference suggested in #220 is maintained.