### PR TITLE
js bridge serialization fixes and optimization

### DIFF
--- a/webview/js/api.py
+++ b/webview/js/api.py
@@ -14,7 +14,7 @@ window.pywebview = {
                 "var promise = new Promise(function(resolve, reject) { " +
                     "window.pywebview._checkValue('" + funcName + "', resolve, reject, __id); " +
                 "}); " +
-                "window.pywebview._bridge.call('" + funcName + "', JSON.stringify(arguments), __id); " +
+                "window.pywebview._bridge.call('" + funcName + "', arguments, __id); " +
                 "return promise;"
 
             window.pywebview.api[funcName] = new Function(params, funcBody)
@@ -28,7 +28,7 @@ window.pywebview = {
                 case 'mshtml':
                 case 'cef':
                 case 'qtwebkit':
-                    return window.external.call(funcName, params, id);
+                    return window.external.call(funcName, JSON.stringify(params), id);
                 case 'edgehtml':
                     return window.external.notify(JSON.stringify([funcName, params, id]));
                 case 'chromium':

--- a/webview/platforms/cef.py
+++ b/webview/platforms/cef.py
@@ -70,7 +70,7 @@ class JSBridge:
         self.eval_events[uid].set()
 
     def call(self, func_name, param, value_id):
-        js_bridge_call(self.window, func_name, param, value_id)
+        js_bridge_call(self.window, func_name, json.loads(param), value_id)
 
 
 renderer = 'cef'

--- a/webview/platforms/mshtml.py
+++ b/webview/platforms/mshtml.py
@@ -40,14 +40,14 @@ from WebBrowserInterop import IWebBrowserInterop, WebBrowserEx
 logger = logging.getLogger('pywebview')
 
 settings = {}
-    
+
 class MSHTML:
     class JSBridge(IWebBrowserInterop):
         __namespace__ = 'MSHTML.JSBridge'
         window = None
 
         def call(self, func_name, param, value_id):
-            return js_bridge_call(self.window, func_name, param, value_id)
+            return js_bridge_call(self.window, func_name, json.loads(param), value_id)
 
         def alert(self, message):
             BrowserView.alert(message)

--- a/webview/util.py
+++ b/webview/util.py
@@ -157,7 +157,7 @@ def js_bridge_call(window, func_name, param, value_id):
 
     if func is not None:
         try:
-            func_params = param if not param else json.loads(param)
+            func_params = param
             t = Thread(target=_call)
             t.start()
         except Exception:
@@ -241,4 +241,3 @@ def interop_dll_path(dll_name):
         pass
 
     raise Exception('Cannot find %s' % dll_name)
-


### PR DESCRIPTION
Hello.

1) In `js/drag.py` there is a call `window.pywebview._bridge.call('moveWindow', [x, y], 'move');`.
Then, if an engine is 'mshtml'/'cef'/'qtwebkit' then `window.external.call(funcName, params, id);` is called in `js/api.py`.
With 'mshtml' that causes an error: `param` is an object of type 'System.__ComObject' and call `window.move(*param)` in `util.py` fails with exception:
```
COMException : Error HRESULT E_FAIL has been returned from a call to a COM component.
   at System.Runtime.InteropServices.Marshal.ThrowExceptionForHRInternal(Int32 errorCode, IntPtr errorInfo)
   at System.Runtime.InteropServices.CustomMarshalers.EnumeratorViewOfEnumVariant.MoveNext()
   at System.Collections.IEnumerator.MoveNext()
   at Python.Runtime.Iterator.tp_iternext(IntPtr ob)
   at window.pywebview._bridge.call (eval code:420:21)
   at onMouseMove (eval code:1299:9)
```

2) About the same call in `js/api.py` (`window.external.call...`).
It is used for 'qtwebkit', but another call is used for 'qtwebengine', with `JSON.stringify(params)`.
But `platforms/qt.py` waits for json-encoded `param` in any case.



Solution for problems 1 and 2 is just to use json-encoding of `params` in any case.
(And `platforms/cef.py` and `platforms/mshtml.py` should be ready for that, another platforms already use json-encoding)
(It is done in `js/api.py` line 31, `platforms/mshtml.py` line 50, `platforms/cef.py` line 73)



3) Now, if we do json-encoding in `window.pywebview._bridge.call` in any case then we do not need additional json-encoding in `window.pywebview.api`.
(It is done in `js/api.py` line 17, `util.py` line 160)
