### PR TITLE
winforms: Implement file type filter on save dialog

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -521,7 +521,10 @@ def create_file_dialog(dialog_type, directory, allow_multiple, save_filename, fi
 
         elif dialog_type == SAVE_DIALOG:
             dialog = WinForms.SaveFileDialog()
-            dialog.Filter = localization['windows.fileFilter.allFiles'] + ' (*.*)|'
+            if len(file_types) > 0:
+                dialog.Filter = '|'.join(['{0} ({1})|{1}'.format(*parse_file_type(f)) for f in file_types])
+            else:
+                dialog.Filter = localization['windows.fileFilter.allFiles'] + ' (*.*)|*.*'
             dialog.InitialDirectory = directory
             dialog.RestoreDirectory = True
             dialog.FileName = save_filename


### PR DESCRIPTION
Winforms save dialogs previously had `*.*` file type filtering hardcoded this in the `create_file_dialog` function, the requested file types were discarded. This could cause issues where the user would select the wrong file extension and the program would subsequently have to fix the file extension and reimplement the "does-this-already-exist" check.

The added code matches that in the open dialog section:
https://github.com/MarkusFF/pywebview/blob/3627e7ac1ca24398330288e548ad074012c76b98/webview/platforms/winforms.py#L510-L513 