### PR TITLE
QtWebEngine: use OTR profile

### DIFF
--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -60,11 +60,12 @@ _debug = False
 _user_agent = None
 _multiprocessing = False
 _http_server = False
+_incognito = True
 
 token = _token
 windows = []
 
-def start(func=None, args=None, localization={}, gui=None, debug=False, http_server=False, user_agent=None):
+def start(func=None, args=None, localization={}, gui=None, debug=False, http_server=False, user_agent=None, incognito=True):
     """
     Start a GUI loop and display previously created windows. This function must
     be called from a main thread.
@@ -82,8 +83,10 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
         window, a separate HTTP server is spawned. This option is ignored for
         non-local URLs.
     :param user_agent: Change user agent string. Not supported in EdgeHTML.
+    :param incognito: Enable incognito mode. Default is True. Non-incognito mode
+        is considered experimental and not supported on all platforms/renderers.
     """
-    global guilib, _debug, _multiprocessing, _http_server, _user_agent
+    global guilib, _debug, _multiprocessing, _http_server, _user_agent, _incognito
 
     def _create_children(other_windows):
         if not windows[0].shown.wait(10):
@@ -97,6 +100,7 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
     #_multiprocessing = multiprocessing
     multiprocessing = False # TODO
     _http_server = http_server
+    _incognito = incognito
 
     if multiprocessing:
         from multiprocessing import Process as Thread

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -15,7 +15,7 @@ from uuid import uuid1
 from copy import deepcopy
 from threading import Semaphore, Event
 
-from webview import _debug, _user_agent, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG, windows
+from webview import _debug, _user_agent, _incognito, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG, windows
 from webview.localization import localization
 from webview.window import Window
 from webview.util import convert_string, default_html, parse_api_js, js_bridge_call
@@ -165,7 +165,7 @@ class BrowserView(QMainWindow):
 
     class WebPage(QWebPage):
         def __init__(self, parent=None):
-            if is_webengine:
+            if is_webengine and _incognito:
                 super(BrowserView.WebPage, self).__init__(BrowserView.otr_profile, parent)
             else:
                 super(BrowserView.WebPage, self).__init__(parent)
@@ -615,8 +615,10 @@ def create_window(window):
         global _app
         _app = QApplication.instance() or QApplication([])
 
-        if is_webengine:
+        if is_webengine and _incognito:
             BrowserView.otr_profile = QWebEngineProfile()
+        elif not is_webengine and not _incognito:
+            logger.warning('qtwebkit does not support incognito=False')
 
         _create()
         _app.exec_()

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -35,7 +35,7 @@ from PyQt5.QtWidgets import QWidget, QMainWindow, QVBoxLayout, QApplication, QFi
 from PyQt5.QtGui import QColor
 
 try:
-    from PyQt5.QtWebEngineWidgets import QWebEngineView as QWebView, QWebEnginePage as QWebPage
+    from PyQt5.QtWebEngineWidgets import QWebEngineView as QWebView, QWebEnginePage as QWebPage, QWebEngineProfile
     from PyQt5.QtWebChannel import QWebChannel
     renderer = 'qtwebengine'
     is_webengine = True
@@ -165,7 +165,10 @@ class BrowserView(QMainWindow):
 
     class WebPage(QWebPage):
         def __init__(self, parent=None):
-            super(BrowserView.WebPage, self).__init__(parent)
+            if is_webengine:
+                super(BrowserView.WebPage, self).__init__(BrowserView.otr_profile, parent)
+            else:
+                super(BrowserView.WebPage, self).__init__(parent)
             if is_webengine:
                 self.featurePermissionRequested.connect(self.onFeaturePermissionRequested)
                 self.nav_handler = BrowserView.NavigationHandler(self)
@@ -445,11 +448,11 @@ class BrowserView(QMainWindow):
         if not self.text_select:
             script = disable_text_select.replace('\n', '')
 
-            try:  
+            try:
                 self.view.page().runJavaScript(script)
             except: # QT < 5.6
                 self.view.page().mainFrame().evaluateJavaScript(script)
-                
+
 
     def set_title(self, title):
         self.set_title_trigger.emit(title)
@@ -611,6 +614,9 @@ def create_window(window):
     if window.uid == 'master':
         global _app
         _app = QApplication.instance() or QApplication([])
+
+        if is_webengine:
+            BrowserView.otr_profile = QWebEngineProfile()
 
         _create()
         _app.exec_()


### PR DESCRIPTION
Use an off-the-record QWebEngineProfile, instead of (unexpectedly) persisting cookies.

Related: #531