### PR TITLE
Only call DestroyIcon if an icon handle was found - fixes #720

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -179,8 +179,7 @@ class BrowserView:
 
             if icon_handle != 0:
                 self.Icon = Icon.FromHandle(IntPtr.op_Explicit(Int32(icon_handle))).Clone()
-
-            windll.user32.DestroyIcon(icon_handle)
+                windll.user32.DestroyIcon(icon_handle)
 
             self.closed = window.closed
             self.closing = window.closing


### PR DESCRIPTION
As discussed in [issue 720](https://github.com/r0x0r/pywebview/issues/720), using pywebview with pystray causes a crash. This is because pywebview calls `windll.user32.DestroyIcon(icon_handle)` regardless of whether an icon handle was actually returned by `windll.shell32.ExtractIconW`. This change just moves the DestroyIcon call to within the null check a few lines above, and fixes the issue.