### PR TITLE
Localization per window

### DIFF
--- a/examples/localization.py
+++ b/examples/localization.py
@@ -24,6 +24,13 @@ if __name__ == '__main__':
         'linux.openFolder': u'Открыть папку',
     }
 
-    webview.create_window('Localization Example', 'https://pywebview.flowrl.com/hello')
-    webview.start(localization=localization)
+    window_localization_override = {
+        'global.saveFile': u'Save file',
+    }
 
+    webview.create_window(
+        'Localization Example',
+        'https://pywebview.flowrl.com/hello',
+        localization=window_localization_override,
+    )
+    webview.start(localization=localization)

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -24,7 +24,7 @@ from webview.event import Event
 from webview.guilib import initialize
 from webview.util import _token, base_uri, parse_file_type, escape_string, make_unicode, escape_line_breaks, WebViewException
 from webview.window import Window
-from .localization import localization as original_localization
+from .localization import original_localization
 from .wsgi import Routing, StaticFiles, StaticResources
 
 
@@ -140,7 +140,7 @@ def create_window(title, url=None, html=None, js_api=None, width=800, height=600
                   resizable=True, fullscreen=False, min_size=(200, 100), hidden=False,
                   frameless=False, easy_drag=True,
                   minimized=False, on_top=False, confirm_close=False, background_color='#FFFFFF',
-                  transparent=False, text_select=False):
+                  transparent=False, text_select=False, localization=None):
     """
     Create a web view window using a native GUI. The execution blocks after this function is invoked, so other
     program logic must be executed in a separate thread.
@@ -172,7 +172,7 @@ def create_window(title, url=None, html=None, js_api=None, width=800, height=600
     window = Window(uid, make_unicode(title), url, html,
                     width, height, x, y, resizable, fullscreen, min_size, hidden,
                     frameless, easy_drag, minimized, on_top, confirm_close, background_color,
-                    js_api, text_select, transparent)
+                    js_api, text_select, transparent, localization)
 
     windows.append(window)
 

--- a/webview/localization.py
+++ b/webview/localization.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-localization = {
+original_localization = {
     'global.quitConfirmation': u'Do you really want to quit?',
     'global.ok': u'OK',
     'global.quit': u'Quit',

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -16,7 +16,6 @@ import WebKit
 from PyObjCTools import AppHelper
 from objc import _objc, nil, super, registerMetaDataForSelector
 
-from webview.localization import localization
 from webview import _debug, _user_agent, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG, parse_file_type, windows
 from webview.util import parse_api_js, default_html, js_bridge_call
 from webview.js.css import disable_text_select
@@ -62,9 +61,9 @@ class BrowserView:
         def windowShouldClose_(self, window):
             i = BrowserView.get_instance('window', window)
 
-            quit = localization['global.quit']
-            cancel = localization['global.cancel']
-            msg = localization['global.quitConfirmation']
+            quit = i.localization['global.quit']
+            cancel = i.localization['global.cancel']
+            msg = i.localization['global.quitConfirmation']
 
             if not i.confirm_close or BrowserView.display_confirmation_dialog(quit, cancel, msg):
                 i.closing.set()
@@ -111,8 +110,9 @@ class BrowserView:
 
         # Display a JavaScript confirm panel containing the specified message
         def webView_runJavaScriptConfirmPanelWithMessage_initiatedByFrame_completionHandler_(self, webview, message, frame, handler):
-            ok = localization['global.ok']
-            cancel = localization['global.cancel']
+            i = BrowserView.get_instance('webkit', webview)
+            ok = i.localization['global.ok']
+            cancel = i.localization['global.cancel']
 
             if not handler.__block_signature__:
                 handler.__block_signature__ = BrowserView.pyobjc_method_signature(b'v@B')
@@ -322,6 +322,7 @@ class BrowserView:
         self.is_fullscreen = False
         self.hidden = window.hidden
         self.minimized = window.minimized
+        self.localization = window.localization
 
         rect = AppKit.NSMakeRect(0.0, 0.0, window.initial_width, window.initial_height)
         window_mask = AppKit.NSTitledWindowMask | AppKit.NSClosableWindowMask | AppKit.NSMiniaturizableWindowMask
@@ -551,7 +552,7 @@ class BrowserView:
                 save_filename = args[2]
 
                 save_dlg = AppKit.NSSavePanel.savePanel()
-                save_dlg.setTitle_(localization['global.saveFile'])
+                save_dlg.setTitle_(self.localization['global.saveFile'])
 
                 if directory:  # set initial directory
                     save_dlg.setDirectoryURL_(Foundation.NSURL.fileURLWithPath_(directory))
@@ -623,28 +624,28 @@ class BrowserView:
         appMenu = AppKit.NSMenu.alloc().init()
         mainAppMenuItem.setSubmenu_(appMenu)
 
-        appMenu.addItemWithTitle_action_keyEquivalent_(self._append_app_name(localization["cocoa.menu.about"]), "orderFrontStandardAboutPanel:", "")
+        appMenu.addItemWithTitle_action_keyEquivalent_(self._append_app_name(self.localization["cocoa.menu.about"]), "orderFrontStandardAboutPanel:", "")
 
         appMenu.addItem_(AppKit.NSMenuItem.separatorItem())
 
         # Set the 'Services' menu for the app and create an app menu item
         appServicesMenu = AppKit.NSMenu.alloc().init()
         self.app.setServicesMenu_(appServicesMenu)
-        servicesMenuItem = appMenu.addItemWithTitle_action_keyEquivalent_(localization["cocoa.menu.services"], nil, "")
+        servicesMenuItem = appMenu.addItemWithTitle_action_keyEquivalent_(self.localization["cocoa.menu.services"], nil, "")
         servicesMenuItem.setSubmenu_(appServicesMenu)
 
         appMenu.addItem_(AppKit.NSMenuItem.separatorItem())
 
         # Append the 'Hide', 'Hide Others', and 'Show All' menu items
-        appMenu.addItemWithTitle_action_keyEquivalent_(self._append_app_name(localization["cocoa.menu.hide"]), "hide:", "h")
-        hideOthersMenuItem = appMenu.addItemWithTitle_action_keyEquivalent_(localization["cocoa.menu.hideOthers"], "hideOtherApplications:", "h")
+        appMenu.addItemWithTitle_action_keyEquivalent_(self._append_app_name(self.localization["cocoa.menu.hide"]), "hide:", "h")
+        hideOthersMenuItem = appMenu.addItemWithTitle_action_keyEquivalent_(self.localization["cocoa.menu.hideOthers"], "hideOtherApplications:", "h")
         hideOthersMenuItem.setKeyEquivalentModifierMask_(AppKit.NSAlternateKeyMask | AppKit.NSCommandKeyMask)
-        appMenu.addItemWithTitle_action_keyEquivalent_(localization["cocoa.menu.showAll"], "unhideAllApplications:", "")
+        appMenu.addItemWithTitle_action_keyEquivalent_(self.localization["cocoa.menu.showAll"], "unhideAllApplications:", "")
 
         appMenu.addItem_(AppKit.NSMenuItem.separatorItem())
 
         # Append a 'Quit' menu item
-        appMenu.addItemWithTitle_action_keyEquivalent_(self._append_app_name(localization["cocoa.menu.quit"]), "terminate:", "q")
+        appMenu.addItemWithTitle_action_keyEquivalent_(self._append_app_name(self.localization["cocoa.menu.quit"]), "terminate:", "q")
 
     def _add_view_menu(self):
         """
@@ -654,13 +655,13 @@ class BrowserView:
 
         # Create an View menu and make it a submenu of the main menu
         viewMenu = AppKit.NSMenu.alloc().init()
-        viewMenu.setTitle_(localization["cocoa.menu.view"])
+        viewMenu.setTitle_(self.localization["cocoa.menu.view"])
         viewMenuItem = AppKit.NSMenuItem.alloc().init()
         viewMenuItem.setSubmenu_(viewMenu)
         mainMenu.addItem_(viewMenuItem)
 
         # TODO: localization of the Enter fullscreen string has no effect
-        fullScreenMenuItem = viewMenu.addItemWithTitle_action_keyEquivalent_(localization["cocoa.menu.fullscreen"], "toggleFullScreen:", "f")
+        fullScreenMenuItem = viewMenu.addItemWithTitle_action_keyEquivalent_(self.localization["cocoa.menu.fullscreen"], "toggleFullScreen:", "f")
         fullScreenMenuItem.setKeyEquivalentModifierMask_(AppKit.NSControlKeyMask | AppKit.NSCommandKeyMask)
 
     def _append_app_name(self, val):

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -15,7 +15,6 @@ except ImportError:
 
 from uuid import uuid1
 from threading import Event, Semaphore
-from webview.localization import localization
 from webview import _debug, _user_agent, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG, parse_file_type, escape_string, windows
 from webview.util import parse_api_js, default_html, js_bridge_call
 from webview.js.css import disable_text_select
@@ -69,6 +68,8 @@ class BrowserView:
 
         self.shown = window.shown
         self.loaded = window.loaded
+
+        self.localization = window.localization
 
         if window.resizable:
             self.window.set_size_request(window.min_size[0], window.min_size[1])
@@ -178,7 +179,7 @@ class BrowserView:
     def on_destroy(self, widget=None, *data):
         dialog = gtk.MessageDialog(parent=self.window, flags=gtk.DialogFlags.MODAL & gtk.DialogFlags.DESTROY_WITH_PARENT,
                                           type=gtk.MessageType.QUESTION, buttons=gtk.ButtonsType.OK_CANCEL,
-                                          message_format=localization['global.quitConfirmation'])
+                                          message_format=self.localization['global.quitConfirmation'])
         result = dialog.run()
         if result == gtk.ResponseType.OK:
             self.close_window()
@@ -301,19 +302,19 @@ class BrowserView:
     def create_file_dialog(self, dialog_type, directory, allow_multiple, save_filename, file_types):
         if dialog_type == FOLDER_DIALOG:
             gtk_dialog_type = gtk.FileChooserAction.SELECT_FOLDER
-            title = localization['linux.openFolder']
+            title = self.localization['linux.openFolder']
             button = gtk.STOCK_OPEN
         elif dialog_type == OPEN_DIALOG:
             gtk_dialog_type = gtk.FileChooserAction.OPEN
             if allow_multiple:
-                title = localization['linux.openFiles']
+                title = self.localization['linux.openFiles']
             else:
-                title = localization['linux.openFile']
+                title = self.localization['linux.openFile']
 
             button = gtk.STOCK_OPEN
         elif dialog_type == SAVE_DIALOG:
             gtk_dialog_type = gtk.FileChooserAction.SAVE
-            title = localization['global.saveFile']
+            title = self.localization['global.saveFile']
             button = gtk.STOCK_SAVE
 
         dialog = gtk.FileChooserDialog(title, self.window, gtk_dialog_type,

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -16,7 +16,6 @@ from copy import deepcopy
 from threading import Semaphore, Event
 
 from webview import _debug, _user_agent, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG, windows
-from webview.localization import localization
 from webview.window import Window
 from webview.util import convert_string, default_html, parse_api_js, js_bridge_call
 from webview.js.css import disable_text_select
@@ -222,6 +221,8 @@ class BrowserView(QMainWindow):
         self.loaded = window.loaded
         self.shown = window.shown
 
+        self.localization = window.localization
+
         self._js_results = {}
         self._current_url = None
         self._file_name = None
@@ -332,17 +333,17 @@ class BrowserView(QMainWindow):
 
     def on_file_dialog(self, dialog_type, directory, allow_multiple, save_filename, file_filter):
         if dialog_type == FOLDER_DIALOG:
-            self._file_name = QFileDialog.getExistingDirectory(self, localization['linux.openFolder'], options=QFileDialog.ShowDirsOnly)
+            self._file_name = QFileDialog.getExistingDirectory(self, self.localization['linux.openFolder'], options=QFileDialog.ShowDirsOnly)
         elif dialog_type == OPEN_DIALOG:
             if allow_multiple:
-                self._file_name = QFileDialog.getOpenFileNames(self, localization['linux.openFiles'], directory, file_filter)
+                self._file_name = QFileDialog.getOpenFileNames(self, self.localization['linux.openFiles'], directory, file_filter)
             else:
-                self._file_name = QFileDialog.getOpenFileName(self, localization['linux.openFile'], directory, file_filter)
+                self._file_name = QFileDialog.getOpenFileName(self, self.localization['linux.openFile'], directory, file_filter)
         elif dialog_type == SAVE_DIALOG:
             if directory:
                 save_filename = os.path.join(str(directory), str(save_filename))
 
-            self._file_name = QFileDialog.getSaveFileName(self, localization['global.saveFile'], save_filename)
+            self._file_name = QFileDialog.getSaveFileName(self, self.localization['global.saveFile'], save_filename)
 
         self._file_name_semaphore.release()
 
@@ -369,7 +370,7 @@ class BrowserView(QMainWindow):
     def closeEvent(self, event):
         self.pywebview_window.closing.set()
         if self.confirm_close:
-            reply = QMessageBox.question(self, self.title, localization['global.quitConfirmation'],
+            reply = QMessageBox.question(self, self.title, self.localization['global.quitConfirmation'],
                                          QMessageBox.Yes, QMessageBox.No)
 
             if reply == QMessageBox.No:

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -20,7 +20,6 @@ from webview import windows, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG
 from webview.guilib import forced_gui_
 from webview.util import parse_file_type, inject_base_uri
 from webview.js import alert
-from webview.localization import localization
 from webview.screen import Screen
 
 try:
@@ -213,6 +212,8 @@ class BrowserView:
             if is_cef:
                 self.Resize += self.on_resize
 
+            self.localization = window.localization
+
         def on_shown(self, sender, args):
             if not is_cef:
                 self.shown.set()
@@ -239,7 +240,7 @@ class BrowserView:
 
         def on_closing(self, sender, args):
             if self.pywebview_window.confirm_close:
-                result = WinForms.MessageBox.Show(localization['global.quitConfirmation'], self.Text,
+                result = WinForms.MessageBox.Show(self.localization['global.quitConfirmation'], self.Text,
                                                 WinForms.MessageBoxButtons.OKCancel, WinForms.MessageBoxIcon.Asterisk)
 
                 if result == WinForms.DialogResult.Cancel:
@@ -507,7 +508,7 @@ def create_file_dialog(dialog_type, directory, allow_multiple, save_filename, fi
             if len(file_types) > 0:
                 dialog.Filter = '|'.join(['{0} ({1})|{1}'.format(*parse_file_type(f)) for f in file_types])
             else:
-                dialog.Filter = localization['windows.fileFilter.allFiles'] + ' (*.*)|*.*'
+                dialog.Filter = window.localization['windows.fileFilter.allFiles'] + ' (*.*)|*.*'
             dialog.RestoreDirectory = True
 
             result = dialog.ShowDialog(window)
@@ -521,7 +522,7 @@ def create_file_dialog(dialog_type, directory, allow_multiple, save_filename, fi
             if len(file_types) > 0:
                 dialog.Filter = '|'.join(['{0} ({1})|{1}'.format(*parse_file_type(f)) for f in file_types])
             else:
-                dialog.Filter = localization['windows.fileFilter.allFiles'] + ' (*.*)|*.*'
+                dialog.Filter = window.localization['windows.fileFilter.allFiles'] + ' (*.*)|*.*'
             dialog.InitialDirectory = directory
             dialog.RestoreDirectory = True
             dialog.FileName = save_filename

--- a/webview/window.py
+++ b/webview/window.py
@@ -4,6 +4,7 @@ import os
 from functools import wraps
 
 from webview.event import Event
+from webview.localization import original_localization
 from webview.serving import resolve_url
 from webview.util import base_uri, parse_file_type, escape_string, make_unicode, WebViewException
 from .js import css
@@ -46,7 +47,7 @@ def _loaded_call(function):
 class Window:
     def __init__(self, uid, title, url, html, width, height, x, y, resizable, fullscreen,
                  min_size, hidden, frameless, easy_drag, minimized, on_top, confirm_close,
-                 background_color, js_api, text_select, transparent):
+                 background_color, js_api, text_select, transparent, localization):
         self.uid = uid
         self.title = make_unicode(title)
         self.original_url = None if html else url  # original URL provided by user
@@ -68,6 +69,7 @@ class Window:
         self.on_top = on_top
         self.minimized = minimized
         self.transparent = transparent
+        self.localization_override = localization
 
         self._js_api = js_api
         self._functions = {}
@@ -96,6 +98,10 @@ class Window:
             self._is_http_server = True
 
         self.real_url = resolve_url(self.original_url, self._is_http_server)
+
+        self.localization = original_localization.copy()
+        if self.localization_override:
+            self.localization.update(self.localization_override)
 
     @property
     def width(self):


### PR DESCRIPTION
This is a bit fiddly due to the `create_window` calls happening before the `webview.start` call, hence the need to update the localization object within the `_initialize` function.

This maintains support for the existing API, the alternative is to remove `localization` from `webview.start` entirely, but this would be a breaking change. Keen to hear your thoughts before proceeding with the other GUI frameworks!

Closes: #697 