### PR TITLE
debugging note

### DIFF
--- a/docs/examples/debug.md
+++ b/docs/examples/debug.md
@@ -1,7 +1,7 @@
 # Debugging
 
 To open up debugging console, right click on an element and select Inspect.
-
+Note: To be able to open the DevTools through the contextmenu, you have to include two parameters inside the start function to be like this: webview.start(debug=True, gui="cef")
 ``` python
 import webview
 


### PR DESCRIPTION
This small note is to demonstrate that, the DevTools through the context menu will not open unless two parameters are included, the debug=True, and gui="cef"