### PR TITLE
Fixing crash when opening inspector in Qt platform

### DIFF
--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -129,7 +129,8 @@ class BrowserView(QMainWindow):
                 url = 'http://localhost:{}'.format(BrowserView.inspector_port)
                 print(url)
                 window = Window('web_inspector', title, url, '', 700, 500, None, None, True, False,
-                                (300, 200), False, False, False, False, False, False, '#fff', None, False, False)
+                                (300, 200), False, False, False, False, False, False, '#fff', None, False, False, None)
+                window.localization = self.parent().localization
 
                 inspector = BrowserView(window)
                 inspector.show()


### PR DESCRIPTION
Hello Roman,

thank you for maintaining such an amazing project! We are using it internally and our whole dev team thinks it is great!

When running version 3.5 under Linux (openSUSE 15.3) and the latest master an app crashes when running with platform='qt' and opening the inspector.

Script to reproduce:
```
import webview

webview.create_window('Test', 'https://pywebview.flowrl.com/')
webview.start(gui='qt', debug=True)
```

Stack trace:
```Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pywebview-3.5-py3.8.egg/webview/platforms/qt.py", line 125, in show_inspector
    BrowserView.instances[uid].raise_()
KeyError: 'master-inspector'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pywebview-3.5-py3.8.egg/webview/platforms/qt.py", line 131, in show_inspector
    window = Window('web_inspector', title, url, '', 700, 500, None, None, True, False,
TypeError: __init__() missing 1 required positional argument: 'localization'
```

This PR fixes the problem.
As I am not 100% familiar with the project structure I tried my best to implement a good fix.

Please let me know if there need to be any changes to the fix.