### PR TITLE
Fix typo in example link

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -195,7 +195,7 @@ window.get_elements(selector)
 
 Return the serialized DOM element by its selector. None if no element matches. For GTK you must have WebKit2 2.22 or greater to use this function.
 
-[Example](/examples/get_element.html)
+[Example](/examples/get_elements.html)
 
 ## hide
 


### PR DESCRIPTION
Hi, cool project!

This is a quick PR for a broken link I found in the documentation.