### PR TITLE
Updated the error message if Microsoft webview2 runtime is not found

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -63,19 +63,31 @@ def _is_edge():
 
 
 def _is_chromium():
-    def edge_build(key):
+    def edge_build(key, description=""):
         try:
             windows_key = None
             if machine() == 'x86':
-                windows_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,  r'SOFTWARE\Microsoft\EdgeUpdate\Clients\\' + key)
+                path = rf"Microsoft\EdgeUpdate\Clients\{key}"
             else:
-                windows_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,  r'SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\\' + key)
+                path = rf"WOW6432Node\Microsoft\EdgeUpdate\Clients\{key}"
+
+            register_key = rf'Computer\HKEY_LOCAL_MACHINE\{path}'
+            windows_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,  rf'SOFTWARE\{path}')
             build, _ = winreg.QueryValueEx(windows_key, 'pv')
             build = int(build.replace('.', '')[:6])
 
             return build
         except Exception as e:
-            logger.debug(e)
+            # Forming extra information
+            extra_info = ""
+            if description != "":
+                extra_info = f"{description} Registry path: {register_key}"
+            else:
+                extra_info = f"Registry path: {register_key}"
+
+            # Adding extra info to error
+            e.strerror += " - " + extra_info
+            logger.debug(e)           
         finally:
             winreg.CloseKey(windows_key)
 
@@ -89,14 +101,14 @@ def _is_chromium():
             return False
 
         build_versions = [
-            '{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}', # runtime
-            '{2CD8A007-E189-409D-A2C8-9AF4EF3C72AA}', # beta
-            '{0D50BFEC-CD6A-4F9A-964C-C7416E3ACB10}', # dev
-            '{65C35B14-6C1D-4122-AC46-7148CC9D6497}' # canary
+            {"key":"{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}", "description":"Microsoft Edge WebView2 Runtime"},  # runtime
+            {"key":"{2CD8A007-E189-409D-A2C8-9AF4EF3C72AA}", "description":"Microsoft Edge WebView2 Beta"}, # beta
+            {"key":"{0D50BFEC-CD6A-4F9A-964C-C7416E3ACB10}", "description":"Microsoft Edge WebView2 Developer"}, # dev
+            {"key":"{65C35B14-6C1D-4122-AC46-7148CC9D6497}", "description":"Microsoft Edge WebView2 Canary"}, # canary
         ]
 
-        for key in build_versions:
-            build = edge_build(key)
+        for item in build_versions:
+            build = edge_build(item["key"], item["description"])
 
             if build >= 860622: # Webview2 86.0.622.0
                 return True

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -63,13 +63,13 @@ def _is_edge():
 
 
 def _is_chromium():
-    def edge_build(key, description=""):
+    def edge_build(key, description=''):
         try:
             windows_key = None
             if machine() == 'x86':
-                path = rf"Microsoft\EdgeUpdate\Clients\{key}"
+                path = rf'Microsoft\EdgeUpdate\Clients\{key}'
             else:
-                path = rf"WOW6432Node\Microsoft\EdgeUpdate\Clients\{key}"
+                path = rf'WOW6432Node\Microsoft\EdgeUpdate\Clients\{key}'
 
             register_key = rf'Computer\HKEY_LOCAL_MACHINE\{path}'
             windows_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,  rf'SOFTWARE\{path}')
@@ -79,14 +79,14 @@ def _is_chromium():
             return build
         except Exception as e:
             # Forming extra information
-            extra_info = ""
-            if description != "":
-                extra_info = f"{description} Registry path: {register_key}"
+            extra_info = ''
+            if description != '':
+                extra_info = f'{description} Registry path: {register_key}'
             else:
-                extra_info = f"Registry path: {register_key}"
+                extra_info = f'Registry path: {register_key}'
 
             # Adding extra info to error
-            e.strerror += " - " + extra_info
+            e.strerror += ' - ' + extra_info
             logger.debug(e)           
         finally:
             winreg.CloseKey(windows_key)
@@ -101,14 +101,14 @@ def _is_chromium():
             return False
 
         build_versions = [
-            {"key":"{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}", "description":"Microsoft Edge WebView2 Runtime"},  # runtime
-            {"key":"{2CD8A007-E189-409D-A2C8-9AF4EF3C72AA}", "description":"Microsoft Edge WebView2 Beta"}, # beta
-            {"key":"{0D50BFEC-CD6A-4F9A-964C-C7416E3ACB10}", "description":"Microsoft Edge WebView2 Developer"}, # dev
-            {"key":"{65C35B14-6C1D-4122-AC46-7148CC9D6497}", "description":"Microsoft Edge WebView2 Canary"}, # canary
+            {'key':'{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}', 'description':'Microsoft Edge WebView2 Runtime'},  # runtime
+            {'key':'{2CD8A007-E189-409D-A2C8-9AF4EF3C72AA}', 'description':'Microsoft Edge WebView2 Beta'}, # beta
+            {'key':'{0D50BFEC-CD6A-4F9A-964C-C7416E3ACB10}', 'description':'Microsoft Edge WebView2 Developer'}, # dev
+            {'key':'{65C35B14-6C1D-4122-AC46-7148CC9D6497}', 'description':'Microsoft Edge WebView2 Canary'}, # canary
         ]
 
         for item in build_versions:
-            build = edge_build(item["key"], item["description"])
+            build = edge_build(item['key'], item['description'])
 
             if build >= 860622: # Webview2 86.0.622.0
                 return True


### PR DESCRIPTION

If we are trying to use "edgechromium" as GUI in webview.start(gui="edgechromium"), it requires a Microsoft webview2 runtime engine. But the error message doesn't show this & instead, it shows,

**[pywebview] [WinError 2] The system cannot find the file specified**

I have updated this error including the detail "Microsoft webview2 runtime engine is not found". Now it will looks like this,

**[pywebview] [WinError 2] The system cannot find the file specified - Microsoft Edge WebView2 Runtime Registry path: Computer\HKEY_LOCAL_MACHINE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}     ts\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}**

Signed-off-by: muthusaravanan <muthusaravanan@solitontech.com>