### PR TITLE
Make Ctrl-C (SIGINT) work on Cocoa when running from the command line…

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -457,6 +457,7 @@ class BrowserView:
             self._add_view_menu()
 
             BrowserView.app.activateIgnoringOtherApps_(Foundation.YES)
+            AppHelper.installMachInterrupt()
             BrowserView.app.run()
 
     def show(self):


### PR DESCRIPTION
This made Ctrl-C work right when running from the command line.