### PR TITLE
Fix signature for Qt window size trigger

### DIFF
--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -66,7 +66,7 @@ class BrowserView(QMainWindow):
     hide_trigger = QtCore.pyqtSignal()
     show_trigger = QtCore.pyqtSignal()
     fullscreen_trigger = QtCore.pyqtSignal()
-    window_size_trigger = QtCore.pyqtSignal(int, int)
+    window_size_trigger = QtCore.pyqtSignal(int, int, FixPoint)
     window_move_trigger = QtCore.pyqtSignal(int, int)
     window_minimize_trigger = QtCore.pyqtSignal()
     window_restore_trigger = QtCore.pyqtSignal()


### PR DESCRIPTION
Qt window size trigger was not set to take the right amount of arguments:
```
js: ERROR Error: Uncaught (in promise): TypeError: BrowserView.window_size_trigger[int, int] signal has 2 argument(s) but 3 provided
...
File ".../webview/platforms/qt.py", line 553, in resize_
    self.window_size_trigger.emit(width, height, fix_point)
TypeError: BrowserView.window_size_trigger[int, int] signal has 2 argument(s) but 3 provided
```
Now `window_size_trigger` has its third argument type added.