### PR TITLE
replace pyqt5 with qtpy

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -84,5 +84,8 @@ pytest tests/test_simple_browser.py
 
 ### Linux 
 * [PyGObject API reference](https://lazka.github.io/pgi-docs/)
-* [PyQt5 reference guide](http://pyqt.sourceforge.net/Docs/PyQt5/)
+
+### Qt
+* [Qt for Python Documentation](https://doc.qt.io/qtforpython-5/contents.html)
 * [Qt5 documentation](https://doc.qt.io/qt-5/index.html)
+* [PySide2 QtWidgets](https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/index.html)

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,7 +4,7 @@
 pip install pywebview
 ```
 
-This will install _pywebview_ with default dependencies. To install _pywebview_ with PyQt5 (available on Linux and macOS) use
+This will install _pywebview_ with default dependencies. To install _pywebview_ with PySide2 (available on Linux and macOS and Windows) use
 
 ``` bash
 pip install pywebview[qt]
@@ -57,11 +57,11 @@ Note that WebKit2 version 2.22 or greater is required for certain features to wo
 
 <br/><br/>
 
-[PyQt5](http://pyqt.sourceforge.net/Docs/PyQt5/index.html) is used with QT. `pywebview` supports both QtWebChannel (newer and preferred) and QtWebKit implementations. Use QtWebChannel, unless it is not available on your system.
+[PySide2](https://doc.qt.io/qtforpython-5/) is used with QT. `pywebview` supports both QtWebChannel (newer and preferred) and QtWebKit implementations. Use QtWebChannel, unless it is not available on your system.
 
 To install QT via pip
 ``` bash
-pip install pyqt5 pyqtwebengine
+pip install qtpy pyside2
 ```
 
 To install QtWebChannel on Debian-based systems.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import platform
 from setuptools import setup
 
 extras_require = {
-    'qt': ['PyQt5', 'pyqtwebengine'],
+    'qt': ['QtPy', 'PySide2'],
     'cef': ['cefpython3'],
     'gtk': ['PyGObject'],
 }
@@ -13,7 +13,7 @@ install_requires = [
     'pyobjc-core ; sys_platform == "darwin"',
     'pyobjc-framework-Cocoa ; sys_platform == "darwin"',
     'pyobjc-framework-WebKit ; sys_platform == "darwin"',
-    'PyQt5 ; sys_platform == "openbsd6"',
+    'QtPy ; sys_platform == "openbsd6" or sys_platform == "win32"',
     'importlib_resources; python_version < "3.7"',
     'proxy_tools',
 ]

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@ import platform
 from setuptools import setup
 
 extras_require = {
-    'qt': ['QtPy', 'PySide2'],
     'cef': ['cefpython3'],
     'gtk': ['PyGObject'],
+    'pyside2': ['QtPy', 'PySide2'],
+    'pyside6': ['QtPy', 'PySide6'],
+    'qt': ['QtPy', 'PyQt5', 'pyqtwebengine'],
 }
 
 install_requires = [

--- a/webview/guilib.py
+++ b/webview/guilib.py
@@ -93,7 +93,10 @@ def initialize(forced_gui=None):
             raise WebViewException('You must have either QT or GTK with Python extensions installed in order to use pywebview.')
 
     elif platform.system() == 'Windows':
-        guis = [import_winforms]
+        if forced_gui == 'qt':
+            guis = [import_qt]
+        else:
+            guis = [import_winforms]
 
         if not try_import(guis):
             raise WebViewException('You must have pythonnet installed in order to use pywebview.')

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -462,6 +462,8 @@ class BrowserView(QMainWindow):
 
         try:    # < Qt5.6
             self.view.page().runJavaScript(script, return_result)
+        except TypeError:
+            self.view.page().runJavaScript(script)  # PySide2 & PySide6
         except AttributeError:
             result = self.view.page().mainFrame().evaluateJavaScript(script)
             return_result(result)

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -27,17 +27,16 @@ logger = logging.getLogger('pywebview')
 
 settings = {}
 
-from PyQt5 import QtCore
-from PyQt5.QtCore import QT_VERSION_STR
+from qtpy import QtCore
 
-logger.debug('Using Qt %s' % QT_VERSION_STR)
+logger.debug('Using Qt %s' % QtCore.__version__)
 
-from PyQt5.QtWidgets import QMainWindow, QApplication, QFileDialog, QMessageBox, QAction
-from PyQt5.QtGui import QColor, QScreen
+from qtpy.QtWidgets import QMainWindow, QApplication, QFileDialog, QMessageBox, QAction
+from qtpy.QtGui import QColor, QScreen
 
 try:
-    from PyQt5.QtWebEngineWidgets import QWebEngineView as QWebView, QWebEnginePage as QWebPage
-    from PyQt5.QtWebChannel import QWebChannel
+    from qtpy.QtWebEngineWidgets import QWebEngineView as QWebView, QWebEnginePage as QWebPage
+    from qtpy.QtWebChannel import QWebChannel
     renderer = 'qtwebengine'
     is_webengine = True
 except ImportError:
@@ -57,22 +56,22 @@ class BrowserView(QMainWindow):
     instances = {}
     inspector_port = None  # The localhost port at which the Remote debugger listens
 
-    create_window_trigger = QtCore.pyqtSignal(object)
-    set_title_trigger = QtCore.pyqtSignal(str)
-    load_url_trigger = QtCore.pyqtSignal(str)
-    html_trigger = QtCore.pyqtSignal(str, str)
-    dialog_trigger = QtCore.pyqtSignal(int, str, bool, str, str)
-    destroy_trigger = QtCore.pyqtSignal()
-    hide_trigger = QtCore.pyqtSignal()
-    show_trigger = QtCore.pyqtSignal()
-    fullscreen_trigger = QtCore.pyqtSignal()
-    window_size_trigger = QtCore.pyqtSignal(int, int)
-    window_move_trigger = QtCore.pyqtSignal(int, int)
-    window_minimize_trigger = QtCore.pyqtSignal()
-    window_restore_trigger = QtCore.pyqtSignal()
-    current_url_trigger = QtCore.pyqtSignal()
-    evaluate_js_trigger = QtCore.pyqtSignal(str, str)
-    on_top_trigger = QtCore.pyqtSignal(bool)
+    create_window_trigger = QtCore.Signal(object)
+    set_title_trigger = QtCore.Signal(str)
+    load_url_trigger = QtCore.Signal(str)
+    html_trigger = QtCore.Signal(str, str)
+    dialog_trigger = QtCore.Signal(int, str, bool, str, str)
+    destroy_trigger = QtCore.Signal()
+    hide_trigger = QtCore.Signal()
+    show_trigger = QtCore.Signal()
+    fullscreen_trigger = QtCore.Signal()
+    window_size_trigger = QtCore.Signal(int, int)
+    window_move_trigger = QtCore.Signal(int, int)
+    window_minimize_trigger = QtCore.Signal()
+    window_restore_trigger = QtCore.Signal()
+    current_url_trigger = QtCore.Signal()
+    evaluate_js_trigger = QtCore.Signal(str, str)
+    on_top_trigger = QtCore.Signal(bool)
 
     class JSBridge(QtCore.QObject):
         qtype = QtCore.QJsonValue if is_webengine else str
@@ -80,7 +79,7 @@ class BrowserView(QMainWindow):
         def __init__(self):
             super(BrowserView.JSBridge, self).__init__()
 
-        @QtCore.pyqtSlot(str, qtype, str, result=str)
+        @QtCore.Slot(str, qtype, str, result=str)
         def call(self, func_name, param, value_id):
             func_name = BrowserView._convert_string(func_name)
             param = BrowserView._convert_string(param)


### PR DESCRIPTION
1. replace pyqt5 with [qtpy](https://pypi.org/project/QtPy/) as abstraction layer in the code, people can freely choose pyqt5, pyside2, pyside6 as the backend
2. replace default pywebview[qt] backend from pyqt5(GPL) to pyside2(LGPL), the LGPL License is more commercial friendly
3. add qt engine support for Windows, people can distribute Qt's built-in Chromium engine, and without requires for users to install additional Webview2(100+MB)

for now [QtWebEngine/ChromiumVersions](https://wiki.qt.io/QtWebEngine/ChromiumVersions)

|PySide2&6|Qt Version|Chromium Version|
| ---------- | ---------- | -------------------|
|PySide6 6.2.3|6.2.0|90.0.4430.228|
|PySide2 5.15.2.1|5.15.2|83.0.4103.122|
