### PR TITLE
#845 Refactor events

### DIFF
--- a/docs/examples/events.md
+++ b/docs/examples/events.md
@@ -45,10 +45,10 @@ def on_loaded():
 if __name__ == '__main__':
     window = webview.create_window('Simple browser', 'https://pywebview.flowrl.com/', confirm_close=True)
 
-    window.closed += on_closed
-    window.closing += on_closing
-    window.shown += on_shown
-    window.loaded += on_loaded
+    window.on_closed += on_closed
+    window.on_closing += on_closing
+    window.on_shown += on_shown
+    window.on_loaded += on_loaded
     window.on_minimized += on_minimized
     window.on_maximized += on_maximized
     window.on_restored += on_restored

--- a/docs/examples/events.md
+++ b/docs/examples/events.md
@@ -45,13 +45,13 @@ def on_loaded():
 if __name__ == '__main__':
     window = webview.create_window('Simple browser', 'https://pywebview.flowrl.com/', confirm_close=True)
 
-    window.on_closed += on_closed
-    window.on_closing += on_closing
-    window.on_shown += on_shown
-    window.on_loaded += on_loaded
-    window.on_minimized += on_minimized
-    window.on_maximized += on_maximized
-    window.on_restored += on_restored
+    window.events.closed += on_closed
+    window.events.closing += on_closing
+    window.events.shown += on_shown
+    window.events.loaded += on_loaded
+    window.events.minimized += on_minimized
+    window.events.maximized += on_maximized
+    window.events.restored += on_restored
 
     webview.start()
 ```

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -303,7 +303,7 @@ Toggle fullscreen mode on the active monitor.
 
 # Events
 
-Window object has a number of lifecycle events. To subscribe to an event, use the `+=` syntax, e.g. `window.on_loaded += func`. The func will be invoked, when event is fired. Duplicate subscriptions are ignored and function is invoked only once for duplicate subscribers. To unsubscribe `window.on_loaded -= func`.
+Window object has a number of lifecycle events. To subscribe to an event, use the `+=` syntax, e.g. `window.events.loaded += func`. The func will be invoked, when event is fired. Duplicate subscriptions are ignored and function is invoked only once for duplicate subscribers. To unsubscribe `window.events.loaded -= func`.
 
 ## closed
 Event fired just before pywebview window is closed.

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -303,7 +303,7 @@ Toggle fullscreen mode on the active monitor.
 
 # Events
 
-Window object has a number of lifecycle events. To subscribe to an event, use the `+=` syntax, e.g. `window.loaded += func`. The func will be invoked, when event is fired. Duplicate subscriptions are ignored and function is invoked only once for duplicate subscribers. To unsubscribe `window.loaded -= func`.
+Window object has a number of lifecycle events. To subscribe to an event, use the `+=` syntax, e.g. `window.on_loaded += func`. The func will be invoked, when event is fired. Duplicate subscriptions are ignored and function is invoked only once for duplicate subscribers. To unsubscribe `window.on_loaded -= func`.
 
 ## closed
 Event fired just before pywebview window is closed.

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -320,17 +320,17 @@ Event fired when DOM is ready.
 
 [Example](/examples/events.html)
 
-## on_minimized
+## minimized
 Event fired when window is minimzed.
 
 [Example](/examples/events.html)
 
-## on_restore
+## restore
 Event fired when window is restored.
 
 [Example](/examples/events.html)
 
-## on_maximized
+## maximized
 Event fired when window is maximized (fullscreen on macOS)
 
 ## shown

--- a/examples/events.py
+++ b/examples/events.py
@@ -32,19 +32,19 @@ def on_loaded():
     print('DOM is ready')
 
     # unsubscribe event listener
-    webview.windows[0].loaded -= on_loaded
+    webview.windows[0].on_loaded -= on_loaded
     webview.windows[0].load_url('https://pywebview.flowrl.com/hello')
 
 
 if __name__ == '__main__':
     window = webview.create_window('Simple browser', 'https://pywebview.flowrl.com/', confirm_close=True)
 
-    window.closed += on_closed
-    window.closing += on_closing
-    window.shown += on_shown
-    window.loaded += on_loaded
+    window.on_closed += on_closed
+    window.on_closing += on_closing
+    window.on_shown += on_shown
+    window.on_loaded += on_loaded
     window.on_minimized += on_minimized
     window.on_maximized += on_maximized
     window.on_restored += on_restored
 
-    webview.start(debug=True)
+    webview.start()

--- a/examples/events.py
+++ b/examples/events.py
@@ -32,19 +32,19 @@ def on_loaded():
     print('DOM is ready')
 
     # unsubscribe event listener
-    webview.windows[0].on_loaded -= on_loaded
+    webview.windows[0].events.loaded -= on_loaded
     webview.windows[0].load_url('https://pywebview.flowrl.com/hello')
 
 
 if __name__ == '__main__':
     window = webview.create_window('Simple browser', 'https://pywebview.flowrl.com/', confirm_close=True)
 
-    window.on_closed += on_closed
-    window.on_closing += on_closing
-    window.on_shown += on_shown
-    window.on_loaded += on_loaded
-    window.on_minimized += on_minimized
-    window.on_maximized += on_maximized
-    window.on_restored += on_restored
+    window.events.closed += on_closed
+    window.events.closing += on_closing
+    window.events.shown += on_shown
+    window.events.loaded += on_loaded
+    window.events.minimized += on_minimized
+    window.events.maximized += on_maximized
+    window.events.restored += on_restored
 
     webview.start()

--- a/webview/platforms/cef.py
+++ b/webview/platforms/cef.py
@@ -86,8 +86,8 @@ class Browser:
         self.browser = browser
         self.text_select = window.text_select
         self.uid = window.uid
-        self.loaded = window.on_loaded
-        self.shown = window.on_shown
+        self.loaded = window.events.loaded
+        self.shown = window.events.shown
         self.inner_hwnd = self.browser.GetWindowHandle()
         self.eval_events = {}
         self.js_bridge = JSBridge(window, self.eval_events)
@@ -258,7 +258,7 @@ def create_browser(window, handle, alert_func):
         cef_browser.SetClientHandler(LoadHandler())
 
         instances[window.uid] = browser
-        window.on_shown.set()
+        window.events.shown.set()
 
     window_info = cef.WindowInfo()
     window_info.SetAsChild(handle)

--- a/webview/platforms/cef.py
+++ b/webview/platforms/cef.py
@@ -86,8 +86,8 @@ class Browser:
         self.browser = browser
         self.text_select = window.text_select
         self.uid = window.uid
-        self.loaded = window.loaded
-        self.shown = window.shown
+        self.loaded = window.on_loaded
+        self.shown = window.on_shown
         self.inner_hwnd = self.browser.GetWindowHandle()
         self.eval_events = {}
         self.js_bridge = JSBridge(window, self.eval_events)
@@ -243,7 +243,7 @@ def init(window):
 def create_browser(window, handle, alert_func):
     def _create():
         real_url = 'data:text/html,{0}'.format(window.html) if window.html else window.real_url or 'data:text/html,{0}'.format(default_html)
-        
+
         default_browser_settings = {}
         all_browser_settings = dict(default_browser_settings, **browser_settings)
 
@@ -258,7 +258,7 @@ def create_browser(window, handle, alert_func):
         cef_browser.SetClientHandler(LoadHandler())
 
         instances[window.uid] = browser
-        window.shown.set()
+        window.on_shown.set()
 
     window_info = cef.WindowInfo()
     window_info.SetAsChild(handle)

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -333,10 +333,10 @@ class BrowserView:
         self._file_name = None
         self._file_name_semaphore = Semaphore(0)
         self._current_url_semaphore = Semaphore(0)
-        self.closed = window.closed
-        self.closing = window.closing
-        self.shown = window.shown
-        self.loaded = window.loaded
+        self.closed = window.on_closed
+        self.closing = window.on_closing
+        self.shown = window.on_shown
+        self.loaded = window.on_loaded
         self.confirm_close = window.confirm_close
         self.title = window.title
         self.text_select = window.text_select

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -90,19 +90,19 @@ class BrowserView:
 
         def windowDidMiniaturize_(self, notification):
             i = BrowserView.get_instance('window', notification.object())
-            i.pywebview_window.on_minimized.set()
+            i.pywebview_window.events.minimized.set()
 
         def windowDidDeminiaturize_(self, notification):
             i = BrowserView.get_instance('window', notification.object())
-            i.pywebview_window.on_restored.set()
+            i.pywebview_window.events.restored.set()
 
         def windowDidEnterFullScreen_(self, notification):
             i = BrowserView.get_instance('window', notification.object())
-            i.pywebview_window.on_maximized.set()
+            i.pywebview_window.events.maximized.set()
 
         def windowDidExitFullScreen_(self, notification):
             i = BrowserView.get_instance('window', notification.object())
-            i.pywebview_window.on_restored.set()
+            i.pywebview_window.events.restored.set()
 
 
     class JSBridge(AppKit.NSObject):
@@ -333,10 +333,10 @@ class BrowserView:
         self._file_name = None
         self._file_name_semaphore = Semaphore(0)
         self._current_url_semaphore = Semaphore(0)
-        self.closed = window.on_closed
-        self.closing = window.on_closing
-        self.shown = window.on_shown
-        self.loaded = window.on_loaded
+        self.closed = window.events.closed
+        self.closing = window.events.closing
+        self.shown = window.events.shown
+        self.loaded = window.events.loaded
         self.confirm_close = window.confirm_close
         self.title = window.title
         self.text_select = window.text_select

--- a/webview/platforms/edgechromium.py
+++ b/webview/platforms/edgechromium.py
@@ -162,4 +162,4 @@ class EdgeChrome:
         if not self.pywebview_window.text_select:
             self.web_view.ExecuteScriptAsync(disable_text_select)
 
-        self.pywebview_window.on_loaded.set()
+        self.pywebview_window.events.loaded.set()

--- a/webview/platforms/edgechromium.py
+++ b/webview/platforms/edgechromium.py
@@ -162,4 +162,4 @@ class EdgeChrome:
         if not self.pywebview_window.text_select:
             self.web_view.ExecuteScriptAsync(disable_text_select)
 
-        self.pywebview_window.loaded.set()
+        self.pywebview_window.on_loaded.set()

--- a/webview/platforms/edgehtml.py
+++ b/webview/platforms/edgehtml.py
@@ -153,7 +153,7 @@ class EdgeHTML:
         if not self.pywebview_window.text_select:
             self.web_view.InvokeScript('eval', (disable_text_select,))
 
-        self.pywebview_window.loaded.set()
+        self.pywebview_window.on_loaded.set()
 
 def _allow_localhost():
     import subprocess

--- a/webview/platforms/edgehtml.py
+++ b/webview/platforms/edgehtml.py
@@ -153,7 +153,7 @@ class EdgeHTML:
         if not self.pywebview_window.text_select:
             self.web_view.InvokeScript('eval', (disable_text_select,))
 
-        self.pywebview_window.on_loaded.set()
+        self.pywebview_window.events.loaded.set()
 
 def _allow_localhost():
     import subprocess

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -67,8 +67,8 @@ class BrowserView:
         glib.threads_init()
         self.window = gtk.Window(title=window.title)
 
-        self.shown = window.shown
-        self.loaded = window.loaded
+        self.shown = window.on_shown
+        self.loaded = window.on_loaded
 
         self.localization = window.localization
 
@@ -160,7 +160,7 @@ class BrowserView:
             self.toggle_fullscreen()
 
     def close_window(self, *data):
-        should_cancel = self.pywebview_window.closing.set()
+        should_cancel = self.pywebview_window.on_closing.set()
 
         if should_cancel:
             return
@@ -177,7 +177,7 @@ class BrowserView:
         if self.pywebview_window in windows:
             windows.remove(self.pywebview_window)
 
-        self.pywebview_window.closed.set()
+        self.pywebview_window.on_closed.set()
 
         if BrowserView.instances == {}:
             gtk.main_quit()

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -67,8 +67,8 @@ class BrowserView:
         glib.threads_init()
         self.window = gtk.Window(title=window.title)
 
-        self.shown = window.on_shown
-        self.loaded = window.on_loaded
+        self.shown = window.events.shown
+        self.loaded = window.events.loaded
 
         self.localization = window.localization
 
@@ -160,7 +160,7 @@ class BrowserView:
             self.toggle_fullscreen()
 
     def close_window(self, *data):
-        should_cancel = self.pywebview_window.on_closing.set()
+        should_cancel = self.pywebview_window.events.closing.set()
 
         if should_cancel:
             return
@@ -177,7 +177,7 @@ class BrowserView:
         if self.pywebview_window in windows:
             windows.remove(self.pywebview_window)
 
-        self.pywebview_window.on_closed.set()
+        self.pywebview_window.events.closed.set()
 
         if BrowserView.instances == {}:
             gtk.main_quit()
@@ -197,16 +197,16 @@ class BrowserView:
         if window_state.changed_mask == Gdk.WindowState.ICONIFIED:
 
             if Gdk.WindowState.ICONIFIED & window_state.new_window_state == Gdk.WindowState.ICONIFIED:
-                self.pywebview_window.on_minimized.set()
+                self.pywebview_window.events.minimized.set()
             else:
-                self.pywebview_window.on_restored.set()
+                self.pywebview_window.events.restored.set()
 
         elif window_state.changed_mask == Gdk.WindowState.MAXIMIZED:
 
             if Gdk.WindowState.MAXIMIZED & window_state.new_window_state == Gdk.WindowState.MAXIMIZED:
-                self.pywebview_window.on_maximized.set()
+                self.pywebview_window.events.maximized.set()
             else:
-                self.pywebview_window.on_restored.set()
+                self.pywebview_window.events.restored.set()
 
 
     def on_webview_ready(self, arg1, arg2):

--- a/webview/platforms/mshtml.py
+++ b/webview/platforms/mshtml.py
@@ -113,7 +113,7 @@ class MSHTML:
 
     def load_html(self, content, base_uri):
         self.web_view.DocumentText = inject_base_uri(content, base_uri)
-        self.pywebview_window.loaded.clear()
+        self.pywebview_window.on_loaded.clear()
 
     def load_url(self, url):
         self.web_view.Navigate(url)
@@ -163,7 +163,7 @@ class MSHTML:
 
         if not self.pywebview_window.text_select:
             document.InvokeScript('eval', (disable_text_select,))
-        self.pywebview_window.loaded.set()
+        self.pywebview_window.on_loaded.set()
 
         if self.pywebview_window.easy_drag:
             document.MouseMove += self.on_mouse_move

--- a/webview/platforms/mshtml.py
+++ b/webview/platforms/mshtml.py
@@ -113,7 +113,7 @@ class MSHTML:
 
     def load_html(self, content, base_uri):
         self.web_view.DocumentText = inject_base_uri(content, base_uri)
-        self.pywebview_window.on_loaded.clear()
+        self.pywebview_window.events.loaded.clear()
 
     def load_url(self, url):
         self.web_view.Navigate(url)
@@ -163,7 +163,7 @@ class MSHTML:
 
         if not self.pywebview_window.text_select:
             document.InvokeScript('eval', (disable_text_select,))
-        self.pywebview_window.on_loaded.set()
+        self.pywebview_window.events.loaded.set()
 
         if self.pywebview_window.easy_drag:
             document.MouseMove += self.on_mouse_move

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -219,8 +219,8 @@ class BrowserView(QMainWindow):
         self._file_name_semaphore = Semaphore(0)
         self._current_url_semaphore = Semaphore(0)
 
-        self.loaded = window.on_loaded
-        self.shown = window.on_shown
+        self.loaded = window.events.loaded
+        self.shown = window.events.shown
 
         self.localization = window.localization
 
@@ -390,7 +390,7 @@ class BrowserView(QMainWindow):
         if self.pywebview_window in windows:
             windows.remove(self.pywebview_window)
 
-        self.pywebview_window.on_closed.set()
+        self.pywebview_window.events.closed.set()
 
         if len(BrowserView.instances) == 0:
             self.hide()
@@ -401,13 +401,13 @@ class BrowserView(QMainWindow):
             return
 
         if self.windowState() == QtCore.Qt.WindowMinimized:
-            self.pywebview_window.on_minimized.set()
+            self.pywebview_window.events.minimized.set()
 
         if self.windowState() == QtCore.Qt.WindowMaximized:
-            self.pywebview_window.on_maximized.set()
+            self.pywebview_window.events.maximized.set()
 
         if self.windowState() == QtCore.Qt.WindowNoState and e.oldState() in (QtCore.Qt.WindowMinimized, QtCore.Qt.WindowMaximized):
-            self.pywebview_window.on_restored.set()
+            self.pywebview_window.events.restored.set()
 
     def on_show_window(self):
         self.show()

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -377,7 +377,7 @@ class BrowserView(QMainWindow):
                 event.ignore()
                 return
 
-        should_cancel = self.pywebview_window.on_closing.set()
+        should_cancel = self.pywebview_window.events.closing.set()
 
         if should_cancel:
             event.ignore()

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -219,8 +219,8 @@ class BrowserView(QMainWindow):
         self._file_name_semaphore = Semaphore(0)
         self._current_url_semaphore = Semaphore(0)
 
-        self.loaded = window.loaded
-        self.shown = window.shown
+        self.loaded = window.on_loaded
+        self.shown = window.on_shown
 
         self.localization = window.localization
 
@@ -377,7 +377,7 @@ class BrowserView(QMainWindow):
                 event.ignore()
                 return
 
-        should_cancel = self.pywebview_window.closing.set()
+        should_cancel = self.pywebview_window.on_closing.set()
 
         if should_cancel:
             event.ignore()
@@ -390,7 +390,7 @@ class BrowserView(QMainWindow):
         if self.pywebview_window in windows:
             windows.remove(self.pywebview_window)
 
-        self.pywebview_window.closed.set()
+        self.pywebview_window.on_closed.set()
 
         if len(BrowserView.instances) == 0:
             self.hide()

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -197,7 +197,7 @@ class BrowserView:
                 windll.user32.DestroyIcon(icon_handle)
 
             self.closed = window.events.closed
-            self.closing = window.on_closing
+            self.closing = window.events.closing
             self.shown = window.events.shown
             self.loaded = window.events.loaded
             self.url = window.real_url

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -196,10 +196,10 @@ class BrowserView:
                 self.Icon = Icon.FromHandle(IntPtr.op_Explicit(Int32(icon_handle))).Clone()
                 windll.user32.DestroyIcon(icon_handle)
 
-            self.closed = window.on_closed
+            self.closed = window.events.closed
             self.closing = window.on_closing
-            self.shown = window.on_shown
-            self.loaded = window.on_loaded
+            self.shown = window.events.shown
+            self.loaded = window.events.loaded
             self.url = window.real_url
             self.text_select = window.text_select
             self.on_top = window.on_top
@@ -275,13 +275,13 @@ class BrowserView:
 
         def on_resize(self, sender, args):
             if self.WindowState == WinForms.FormWindowState.Maximized:
-                self.pywebview_window.on_maximized.set()
+                self.pywebview_window.events.maximized.set()
 
             if self.WindowState == WinForms.FormWindowState.Minimized:
-                self.pywebview_window.on_minimized.set()
+                self.pywebview_window.events.minimized.set()
 
             if self.WindowState == WinForms.FormWindowState.Normal and self.old_state in (WinForms.FormWindowState.Minimized, WinForms.FormWindowState.Maximized):
-                self.pywebview_window.on_restored.set()
+                self.pywebview_window.events.restored.set()
 
             self.old_state = self.WindowState
 
@@ -587,13 +587,13 @@ def get_current_url(uid):
         return CEF.get_current_url(uid)
     else:
         window = BrowserView.instances[uid]
-        window.on_loaded.wait()
+        window.events.loaded.wait()
         return window.browser.url
 
 
 def load_url(url, uid):
     window = BrowserView.instances[uid]
-    window.on_loaded.clear()
+    window.events.loaded.clear()
 
     if is_cef:
         CEF.load_url(url, uid)

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -587,13 +587,13 @@ def get_current_url(uid):
         return CEF.get_current_url(uid)
     else:
         window = BrowserView.instances[uid]
-        window.events.loaded.wait()
+        window.loaded.wait()
         return window.browser.url
 
 
 def load_url(url, uid):
     window = BrowserView.instances[uid]
-    window.events.loaded.clear()
+    window.loaded.clear()
 
     if is_cef:
         CEF.load_url(url, uid)

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -196,10 +196,10 @@ class BrowserView:
                 self.Icon = Icon.FromHandle(IntPtr.op_Explicit(Int32(icon_handle))).Clone()
                 windll.user32.DestroyIcon(icon_handle)
 
-            self.closed = window.closed
-            self.closing = window.closing
-            self.shown = window.shown
-            self.loaded = window.loaded
+            self.closed = window.on_closed
+            self.closing = window.on_closing
+            self.shown = window.on_shown
+            self.loaded = window.on_loaded
             self.url = window.real_url
             self.text_select = window.text_select
             self.on_top = window.on_top
@@ -587,13 +587,13 @@ def get_current_url(uid):
         return CEF.get_current_url(uid)
     else:
         window = BrowserView.instances[uid]
-        window.loaded.wait()
+        window.on_loaded.wait()
         return window.browser.url
 
 
 def load_url(url, uid):
     window = BrowserView.instances[uid]
-    window.loaded.clear()
+    window.on_loaded.clear()
 
     if is_cef:
         CEF.load_url(url, uid)

--- a/webview/window.py
+++ b/webview/window.py
@@ -21,7 +21,7 @@ def _api_call(function, event_type):
     """
     @wraps(function)
     def wrapper(*args, **kwargs):
-        event = args[0].loaded if event_type == 'loaded' else args[0].shown
+        event = args[0].on_loaded if event_type == 'loaded' else args[0].on_shown
 
         try:
             if not event.wait(15):
@@ -82,10 +82,15 @@ class Window:
         self._js_api = js_api
         self._functions = {}
 
-        self.closed = Event()
-        self.closing = Event(True)
-        self.loaded = Event()
-        self.shown = Event()
+        self.on_closed = Event()
+        self.on_closing = Event(True)
+        self.on_loaded = Event()
+        self.on_shown = Event()
+
+        self._closed = self.on_closed
+        self._closing = self.on_closing
+        self._loaded = self.on_loaded
+        self._shown = self.on_shown
 
         # new naming format of events. 4.0 will migrate all the events to this format
         self.on_minimized = Event()
@@ -97,8 +102,8 @@ class Window:
 
     def _initialize(self, gui, multiprocessing, http_server):
         self.gui = gui
-        self.loaded._initialize(multiprocessing)
-        self.shown._initialize(multiprocessing)
+        self.on_loaded._initialize(multiprocessing)
+        self.on_shown._initialize(multiprocessing)
         self._is_http_server = http_server
 
         # WebViewControl as of 5.1.1 crashes on file:// urls. Stupid workaround to make it work
@@ -117,26 +122,62 @@ class Window:
             self.localization.update(self.localization_override)
 
     @property
+    def shown(self):
+        logger.warning('shown event is deprecated and will be removed in 4.0. Use on_shown instead')
+        return self.on_shown
+
+    @shown.setter
+    def shown(self, value):
+        self.on_shown = value
+
+    @property
+    def loaded(self):
+        logger.warning('loaded event is deprecated and will be removed in 4.0. Use on_loaded instead')
+        return self.on_loaded
+
+    @loaded.setter
+    def shown(self, value):
+        self.on_loaded = value
+
+    @property
+    def closed(self):
+        logger.warning('closed event is deprecated and will be removed in 4.0. Use on_closed instead')
+        return self.on_closed
+
+    @closed.setter
+    def closed(self, value):
+        self.on_closed = value
+
+    @property
+    def closing(self):
+        logger.warning('closing event is deprecated and will be removed in 4.0. Use on_closing instead')
+        return self.on_closed
+
+    @closing.setter
+    def closing(self, value):
+        self.on_closing = value
+
+    @property
     def width(self):
-        self.shown.wait(15)
+        self.on_shown.wait(15)
         width, _ = self.gui.get_size(self.uid)
         return width
 
     @property
     def height(self):
-        self.shown.wait(15)
+        self.on_shown.wait(15)
         _, height = self.gui.get_size(self.uid)
         return height
 
     @property
     def x(self):
-        self.shown.wait(15)
+        self.on_shown.wait(15)
         x, _ = self.gui.get_position(self.uid)
         return x
 
     @property
     def y(self):
-        self.shown.wait(15)
+        self.on_shown.wait(15)
         _, y = self.gui.get_position(self.uid)
         return y
 
@@ -346,5 +387,5 @@ class Window:
                 'params': params
             })
 
-        if self.loaded.is_set():
+        if self.on_loaded.is_set():
             self.evaluate_js('window.pywebview._createApi(%s)' % func_list)

--- a/webview/window.py
+++ b/webview/window.py
@@ -21,7 +21,7 @@ def _api_call(function, event_type):
     """
     @wraps(function)
     def wrapper(*args, **kwargs):
-        event = args[0].on_loaded if event_type == 'loaded' else args[0].on_shown
+        event = args[0].events.loaded if event_type == 'loaded' else args[0].events.shown
 
         try:
             if not event.wait(15):
@@ -50,6 +50,10 @@ class FixPoint(Flag):
     WEST = auto()
     EAST = auto()
     SOUTH = auto()
+
+
+class EventContainer:
+    pass
 
 
 class Window:
@@ -82,28 +86,29 @@ class Window:
         self._js_api = js_api
         self._functions = {}
 
-        self.on_closed = Event()
-        self.on_closing = Event(True)
-        self.on_loaded = Event()
-        self.on_shown = Event()
+        self.events = EventContainer()
+        self.events.closed = Event()
+        self.events.closing = Event(True)
+        self.events.loaded = Event()
+        self.events.shown = Event()
 
-        self._closed = self.on_closed
-        self._closing = self.on_closing
-        self._loaded = self.on_loaded
-        self._shown = self.on_shown
+        self._closed = self.events.closed
+        self._closing = self.events.closing
+        self._loaded = self.events.loaded
+        self._shown = self.events.shown
 
         # new naming format of events. 4.0 will migrate all the events to this format
-        self.on_minimized = Event()
-        self.on_maximized = Event()
-        self.on_restored = Event()
+        self.events.minimized = Event()
+        self.events.maximized = Event()
+        self.events.restored = Event()
 
         self.gui = None
         self._is_http_server = False
 
     def _initialize(self, gui, multiprocessing, http_server):
         self.gui = gui
-        self.on_loaded._initialize(multiprocessing)
-        self.on_shown._initialize(multiprocessing)
+        self.events.loaded._initialize(multiprocessing)
+        self.events.shown._initialize(multiprocessing)
         self._is_http_server = http_server
 
         # WebViewControl as of 5.1.1 crashes on file:// urls. Stupid workaround to make it work
@@ -124,34 +129,34 @@ class Window:
     @property
     def shown(self):
         logger.warning('shown event is deprecated and will be removed in 4.0. Use on_shown instead')
-        return self.on_shown
+        return self.events.shown
 
     @shown.setter
     def shown(self, value):
-        self.on_shown = value
+        self.events.shown = value
 
     @property
     def loaded(self):
         logger.warning('loaded event is deprecated and will be removed in 4.0. Use on_loaded instead')
-        return self.on_loaded
+        return self.events.loaded
 
     @loaded.setter
     def shown(self, value):
-        self.on_loaded = value
+        self.events.loaded = value
 
     @property
     def closed(self):
         logger.warning('closed event is deprecated and will be removed in 4.0. Use on_closed instead')
-        return self.on_closed
+        return self.events.closed
 
     @closed.setter
     def closed(self, value):
-        self.on_closed = value
+        self.events.closed = value
 
     @property
     def closing(self):
         logger.warning('closing event is deprecated and will be removed in 4.0. Use on_closing instead')
-        return self.on_closed
+        return self.events.closed
 
     @closing.setter
     def closing(self, value):
@@ -159,25 +164,25 @@ class Window:
 
     @property
     def width(self):
-        self.on_shown.wait(15)
+        self.events.shown.wait(15)
         width, _ = self.gui.get_size(self.uid)
         return width
 
     @property
     def height(self):
-        self.on_shown.wait(15)
+        self.events.shown.wait(15)
         _, height = self.gui.get_size(self.uid)
         return height
 
     @property
     def x(self):
-        self.on_shown.wait(15)
+        self.events.shown.wait(15)
         x, _ = self.gui.get_position(self.uid)
         return x
 
     @property
     def y(self):
-        self.on_shown.wait(15)
+        self.events.shown.wait(15)
         _, y = self.gui.get_position(self.uid)
         return y
 
@@ -387,5 +392,5 @@ class Window:
                 'params': params
             })
 
-        if self.on_loaded.is_set():
+        if self.events.loaded.is_set():
             self.evaluate_js('window.pywebview._createApi(%s)' % func_list)

--- a/webview/window.py
+++ b/webview/window.py
@@ -128,7 +128,7 @@ class Window:
 
     @property
     def shown(self):
-        logger.warning('shown event is deprecated and will be removed in 4.0. Use on_shown instead')
+        logger.warning('shown event is deprecated and will be removed in 4.0. Use events.shown instead')
         return self.events.shown
 
     @shown.setter
@@ -137,7 +137,7 @@ class Window:
 
     @property
     def loaded(self):
-        logger.warning('loaded event is deprecated and will be removed in 4.0. Use on_loaded instead')
+        logger.warning('loaded event is deprecated and will be removed in 4.0. Use events.loaded instead')
         return self.events.loaded
 
     @loaded.setter
@@ -146,7 +146,7 @@ class Window:
 
     @property
     def closed(self):
-        logger.warning('closed event is deprecated and will be removed in 4.0. Use on_closed instead')
+        logger.warning('closed event is deprecated and will be removed in 4.0. Use events.closed instead')
         return self.events.closed
 
     @closed.setter
@@ -155,7 +155,7 @@ class Window:
 
     @property
     def closing(self):
-        logger.warning('closing event is deprecated and will be removed in 4.0. Use on_closing instead')
+        logger.warning('closing event is deprecated and will be removed in 4.0. Use events.closing instead')
         return self.events.closed
 
     @closing.setter


### PR DESCRIPTION
Put window events into its own namespace `window.events`. Old events are still supported with a deprecation warning. Old events will be eventually removed in 4.0
#845 