### PR TITLE
#904 #905 #906 Fix callback return value in async evaluate_js

### DIFF
--- a/webview/window.py
+++ b/webview/window.py
@@ -364,7 +364,7 @@ class Window:
                     value.then(function evaluate_async(result) {{
                         pywebview._asyncCallback(JSON.stringify(result), "{1}")
                     }});
-                    true;
+                    "true";
                 }} else {{ {2} }}
             """.format(escape_string(script), unique_id, sync_eval)
         else:


### PR DESCRIPTION
Javascript generated for asynchronous evaluate_js call returned an actual boolean instead of a JSON stringified boolean.