### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/examples/minimize_window.md
+++ b/docs/examples/minimize_window.md
@@ -1,7 +1,7 @@
 
 # Minimize / restore window
 
-Minimize and restore window programmmatically
+Minimize and restore window programmatically
 
 
 ```python

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -331,7 +331,7 @@ Event fired when DOM is ready.
 [Example](/examples/events.html)
 
 ## events.minimized
-Event fired when window is minimzed.
+Event fired when window is minimized.
 
 [Example](/examples/events.html)
 
@@ -364,7 +364,7 @@ _pywebview_ exposes a `window.pywebviewready` DOM event that is fired when `wind
 
 # Drag area
 
-_pywebview_ window can be moved by dragging any element with the `pywebview-drag-region` class name. This is useful, for example, in frameless mode when you would like to implement a custom caption bar. The magic class name can be overriden by re-assigning the `webview.DRAG_REGION_SELECTOR` constant.
+_pywebview_ window can be moved by dragging any element with the `pywebview-drag-region` class name. This is useful, for example, in frameless mode when you would like to implement a custom caption bar. The magic class name can be overridden by re-assigning the `webview.DRAG_REGION_SELECTOR` constant.
 
 
 [Example](/examples/js_api.html)

--- a/docs/guide/interdomain.md
+++ b/docs/guide/interdomain.md
@@ -3,7 +3,7 @@
 
 ## Invoke Javascript from Python
 
-`window.evaluate_js(code, callback=None)` allows you to execute arbitrary Javascript code with a last value returned syncronously. If callback function is supplied, then promises are resolved and the callback function is called with the result as a parameter. Javascript types are converted to Python types, eg. JS objects to dicts, arrays to lists, undefined to None. Note that due implementation limitations the string 'null' will be evaluated to None.
+`window.evaluate_js(code, callback=None)` allows you to execute arbitrary Javascript code with a last value returned synchronously. If callback function is supplied, then promises are resolved and the callback function is called with the result as a parameter. Javascript types are converted to Python types, eg. JS objects to dicts, arrays to lists, undefined to None. Note that due implementation limitations the string 'null' will be evaluated to None.
 You must escape \n and \r among other escape sequences if they present in Javascript code. Otherwise they get parsed by Python. r'strings' is a recommended way to load Javascript. For GTK WebKit2 versions older than 2.22, there is a limit of about ~900 characters for a value returned by `evaluate_js`.
 
 

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -69,7 +69,7 @@ pass
 
 # Make Python and Javascript talk with each other
 
-You can think of custom logic as a backend that communicates with frontend code in the HTML/JS realm. Now how would you make two to communicate with each other? _pywebview_ offers a two way JS-Python bridge that lets you both execute Javascript from Python (via `evaluate_js`) and Python code from Javascript (via `js_api` and `expose`). See [interdomain commmunication](/guide/interdomain.md) for details. Another way is to run a Python web server (like Flask or Bottle) in custom logic and make frontend code make API calls to it. That would be identical to a typical web application. This approach is suitable, for example, for porting an existing web application to a desktop application. See [Architecture](/guide/architecture.md) for more information on both approaches.
+You can think of custom logic as a backend that communicates with frontend code in the HTML/JS realm. Now how would you make two to communicate with each other? _pywebview_ offers a two way JS-Python bridge that lets you both execute Javascript from Python (via `evaluate_js`) and Python code from Javascript (via `js_api` and `expose`). See [interdomain communication](/guide/interdomain.md) for details. Another way is to run a Python web server (like Flask or Bottle) in custom logic and make frontend code make API calls to it. That would be identical to a typical web application. This approach is suitable, for example, for porting an existing web application to a desktop application. See [Architecture](/guide/architecture.md) for more information on both approaches.
 
 
 

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -220,7 +220,7 @@ class BrowserView:
                 CEF.create_browser(window, self.Handle.ToInt32(), BrowserView.alert)
             elif is_chromium:
                 self.browser = Chromium.EdgeChrome(self, window)
-                # for chromium edge, need this factor to modify the cordinates
+                # for chromium edge, need this factor to modify the coordinates
                 self.scale_factor = windll.shcore.GetScaleFactorForDevice(0)/100
             elif is_edge:
                 self.browser = Edge.EdgeHTML(self, window)

--- a/webview/wsgi.py
+++ b/webview/wsgi.py
@@ -168,7 +168,7 @@ class Routing(dict):
 
 class StaticContentsApp:
     """
-    Base class for static serving implementatins
+    Base class for static serving implementations
     """
     max_age = 60  # 1min, takes the edge off any frequent responses while staying fresh
 


### PR DESCRIPTION
There are small typos in:
- docs/examples/minimize_window.md
- docs/guide/api.md
- docs/guide/interdomain.md
- docs/guide/usage.md
- webview/platforms/winforms.py
- webview/wsgi.py

Fixes:
- Should read `synchronously` rather than `syncronously`.
- Should read `programmatically` rather than `programmmatically`.
- Should read `overridden` rather than `overriden`.
- Should read `minimized` rather than `minimzed`.
- Should read `implementations` rather than `implementatins`.
- Should read `coordinates` rather than `cordinates`.
- Should read `communication` rather than `commmunication`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md