### PR TITLE
Run menu functions on thread

### DIFF
--- a/examples/menu.py
+++ b/examples/menu.py
@@ -24,6 +24,10 @@ def say_this_is_window_2():
     if active_window:
         active_window.load_html('<h1>This is window 2</h2>')
 
+def open_file_dialog():
+    active_window = webview.active_window()
+    active_window.create_file_dialog(webview.SAVE_DIALOG, directory='/', save_filename='test.file')
+
 
 if __name__ == '__main__':
     window_1 = webview.create_window('Application Menu Example', 'https://pywebview.flowrl.com/hello')
@@ -38,7 +42,8 @@ if __name__ == '__main__':
                 wm.Menu(
                     'Random',
                     [
-                        wm.MenuAction('Click Me', click_me)
+                        wm.MenuAction('Click Me', click_me),
+                        wm.MenuAction('File Dialog', open_file_dialog)
                     ]
                 )
             ]

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -8,7 +8,7 @@ import json
 import logging
 import webbrowser
 import ctypes
-from threading import Semaphore
+from threading import Semaphore, Thread
 import typing as t
 
 import Foundation
@@ -918,7 +918,8 @@ def set_app_menu(app_menu_list):
             item.setTarget_(self)
 
         def _call_action(self):
-            self.action()
+            # Don't run action function on main thread
+            Thread(target=self.action).start()
 
     def create_submenu(title, line_items, supermenu):
         m = InternalMenu(title, parent=supermenu)

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -10,7 +10,7 @@ import os
 import webbrowser
 
 from uuid import uuid1
-from threading import Semaphore
+from threading import Semaphore, Thread
 
 from webview import _debug, _private_mode, _user_agent, _storage_path, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG, parse_file_type, windows
 from webview.util import parse_api_js, default_html, js_bridge_call
@@ -605,7 +605,8 @@ def set_app_menu(app_menu_list):
         function = _app_actions.get(action.get_name())
         if function is None:
             return
-        function()
+        # Don't run action function on main thread
+        Thread(target=function).start()
 
     def create_submenu(title, line_items, supermenu, action_prepend=''):
         m = Gio.Menu.new()

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -13,7 +13,7 @@ import webbrowser
 import socket
 from uuid import uuid1
 from copy import deepcopy
-from threading import Semaphore, Event
+from threading import Semaphore, Event, Thread
 import typing as t
 
 from webview import _debug, _user_agent, _private_mode, _storage_path, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG, windows

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -12,7 +12,7 @@ import logging
 import webbrowser
 import socket
 from uuid import uuid1
-from copy import deepcopy
+from copy import copy, deepcopy
 from threading import Semaphore, Event, Thread
 import typing as t
 
@@ -726,13 +726,15 @@ def set_app_menu(app_menu_list):
                 m.addSeparator()
             elif isinstance(menu_line_item, MenuAction):
                 new_action = QAction(menu_line_item.title)
-                new_action.triggered.connect(Thread(target=menu_line_item.function).start)
+                func = copy(menu_line_item.function)
+                new_action.triggered.connect(lambda: Thread(target=func).start())
                 m.addAction(new_action)
                 BrowserView.global_menubar_other_objects.append(new_action)
             elif isinstance(menu_line_item, Menu):
                 create_submenu(menu_line_item.title, menu_line_item.items, m)
 
         return m
+
 
     # If the application menu has already been created, we don't want to do it again
     if len(BrowserView.global_menubar_top_menus) > 0 or len(BrowserView.global_menubar_other_objects) > 0:

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -726,7 +726,7 @@ def set_app_menu(app_menu_list):
                 m.addSeparator()
             elif isinstance(menu_line_item, MenuAction):
                 new_action = QAction(menu_line_item.title)
-                new_action.triggered.connect(menu_line_item.function)
+                new_action.triggered.connect(Thread(target=menu_line_item.function).start)
                 m.addAction(new_action)
                 BrowserView.global_menubar_other_objects.append(new_action)
             elif isinstance(menu_line_item, Menu):

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -9,7 +9,7 @@ http://github.com/r0x0r/pywebview/
 import os
 import sys
 import logging
-from threading import Event
+from threading import Event, Thread
 import ctypes
 from ctypes import windll
 from uuid import uuid4
@@ -335,7 +335,8 @@ class BrowserView:
                             continue
                         elif isinstance(menu_line_item, MenuAction):
                             action_item = WinForms.ToolStripMenuItem(menu_line_item.title)
-                            action_item.Click += lambda _,__,menu_line_item=menu_line_item : menu_line_item.function()
+                            # Don't run action function on main thread
+                            action_item.Click += lambda _,__,menu_line_item=menu_line_item : Thread(target=menu_line_item.function).start()
                             m.DropDownItems.Add(action_item)
                         elif isinstance(menu_line_item, Menu):
                             create_submenu(menu_line_item.title, menu_line_item.items, m)


### PR DESCRIPTION
Certain functions would freeze the app when called from the menu because they were running on the main thread. Instead, call the functions from a thread.

Has been tested on Mac, needs to be tested on Linux and Windows. Can be tested by running `examples/menu.py` and selecting the menu option at *Test Menu > Random > File Dialog*. This should show a file dialog without freezing.