### PR TITLE
[WinForms] Fix hang on window closing when JS evaluation is in progress

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -249,6 +249,10 @@ class BrowserView:
                     CEF.shutdown()
                 WinForms.Application.Exit()
 
+            if not is_cef:
+                # stop waiting for JS result
+                self.browser.js_result_semaphore.release()
+
             if is_cef:
                 CEF.close_window(self.uid)
 
@@ -309,9 +313,7 @@ class BrowserView:
             if is_chromium or is_edge:
                 if self.browser.js_results.get(id, None) is None:
                     time.sleep(.1)
-                result = self.browser.js_results[id]
-                self.browser.js_results.pop(id)
-                return result
+                return self.browser.js_results.pop(id, None)
 
             return self.browser.js_result
 


### PR DESCRIPTION
This PR fixes the issue reported at https://github.com/r0x0r/pywebview/issues/433#issuecomment-622522261 for WinForms. The JS result semaphore is released, and `None` is returned from `evaluate_js`. This is modeled on what is done for the GTK platform. 