### PR TITLE
Avoid control-left-click context menu on MacOS, also allow right-click events to reach javascript handlers

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -276,7 +276,8 @@ class BrowserView:
             super(BrowserView.WebKitHost, self).mouseDown_(event)
 
         def willOpenMenu_withEvent_(self, menu, event):
-            menu.removeAllItems()
+            if not _debug['mode']:
+                menu.removeAllItems()
 
         def performKeyEquivalent_(self, theEvent):
             """

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -275,10 +275,8 @@ class BrowserView:
 
             super(BrowserView.WebKitHost, self).mouseDown_(event)
 
-        def rightMouseDown_(self, event):
-            i = BrowserView.get_instance('webkit', self)
-            if _debug['mode']:
-                super(BrowserView.WebKitHost, self).rightMouseDown_(event)
+        def willOpenMenu_withEvent_(self, menu, event):
+            menu.removeAllItems()
 
         def performKeyEquivalent_(self, theEvent):
             """


### PR DESCRIPTION
Change 8c3b47b9533fe9d5980df15fcf2596603cfc461d was done to disable right-click context menus (for issue [#12](../../pywebview/issues/12)).  But currently on MacOS, the context menu can still be activated by ctrl-left-clicking.  I think maybe it used to be disabled in both cases, but the code was changed later, maybe because the original code used a method that's now deprecated?  (webView_contextMenuItemsForElement_defaultMenuItems_ was overridden to return nil, which clears/prevents the menu.)

The current code disables the menu by overriding WKWebView.rightMouseDown_ and does not call the super (unless `_debug['mode']` is true), which would normally activate the menu.

In addition to the fact that ctrl-left-clicking still activates the menu, a second problem I ran into is that circumventing the built-in rightMouseDown_ prevents javascript "mousedown" and "pointerdown" event handlers from seeing right-clicks.

This PR proposes to fix both problems by removing the rightMouseDown_ override, and adding a new override of willOpenMenu_withEvent_ that clears/prevents the menu regardless of what triggered it.