### PR TITLE
Return False from performKeyEquivalent_ in unhandled cases.  Remove cursor workarounds.

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -279,47 +279,38 @@ class BrowserView:
             if not _debug['mode']:
                 menu.removeAllItems()
 
-        def performKeyEquivalent_(self, theEvent):
-            """
-            Handle common hotkey shortcuts as copy/cut/paste/undo/select all/quit
-            :param theEvent:
-            :return:
-            """
-
-            if theEvent.type() == AppKit.NSKeyDown and theEvent.modifierFlags() & AppKit.NSCommandKeyMask:
+        def keyDown_(self, event):
+            if event.modifierFlags() & AppKit.NSCommandKeyMask:
                 responder = self.window().firstResponder()
-                keyCode = theEvent.keyCode()
-
                 if responder != None:
-                    handled = False
+                    keyCode = event.keyCode()
                     range_ = responder.selectedRange()
                     hasSelectedText = len(range_) > 0
 
-                    if keyCode == 7 and hasSelectedText : #cut
+                    if keyCode == 7 and hasSelectedText:  # cut
                         responder.cut_(self)
-                        handled = True
-                    elif keyCode == 8 and hasSelectedText:  #copy
+                        return
+                    elif keyCode == 8 and hasSelectedText:  # copy
                         responder.copy_(self)
-                        handled = True
+                        return
                     elif keyCode == 9:  # paste
                         responder.paste_(self)
-                        handled = True
+                        return
                     elif keyCode == 0:  # select all
                         responder.selectAll_(self)
-                        handled = True
+                        return
                     elif keyCode == 6:  # undo
                         if responder.undoManager().canUndo():
                             responder.undoManager().undo()
-                            handled = True
+                        return
                     elif keyCode == 12:  # quit
                         BrowserView.app.stop_(self)
-                    elif keyCode == 13:  # w (close)
-                        self.window().performClose_(theEvent)
-                        handled = True
+                        return
+                    elif keyCode == 13:  # close
+                        self.window().performClose_(event)
+                        return
 
-                    return handled
-
-            return False
+            super(BrowserView.WebKitHost, self).keyDown_(event)
 
 
     def __init__(self, window):

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -286,13 +286,6 @@ class BrowserView:
             :return:
             """
 
-            # Fix arrow keys not responding in text inputs
-            keyCode_ = theEvent.keyCode()
-            UP, DOWN, LEFT, RIGHT, DELETE, PG_DWN, PG_UP = 126, 125, 123, 124, 117, 121, 116
-
-            if keyCode_ in (UP, DOWN, LEFT, RIGHT, DELETE, PG_DWN, PG_UP):
-                return False
-
             if theEvent.type() == AppKit.NSKeyDown and theEvent.modifierFlags() & AppKit.NSCommandKeyMask:
                 responder = self.window().firstResponder()
                 keyCode = theEvent.keyCode()
@@ -326,7 +319,7 @@ class BrowserView:
 
                     return handled
 
-            return True
+            return False
 
 
     def __init__(self, window):


### PR DESCRIPTION
Fixes 2nd issue in [#996](../../pywebview/issues/996), allowing any key combinations _not_ handled by `performKeyEquivalent_()` to reach javascript event handlers.