### PR TITLE
Fix for multiple servers starting when not necessary.

### DIFF
--- a/examples/multiple_servers.py
+++ b/examples/multiple_servers.py
@@ -57,12 +57,12 @@ def hello():
                         <tr>
                             <td>Global Server</td>
                             <td>{serverDescription(webview.http.global_server)}</td>
-                            <td>{webview.http.global_server.address}</td>
+                            <td>{webview.http.global_server.address if not webview.http.global_server is None else 'None'}</td>
                         </tr>
                         <tr>
                             <td>First Window</td>
                             <td>{serverDescription(windows[0]._server)}</td>
-                            <td>{windows[0]._server.address}</td>
+                            <td>{windows[0]._server.address if not windows[0]._server is None else 'None'}</td>
                         </tr>
                         <tr>
                             <td>Second Window</td>
@@ -89,4 +89,4 @@ if __name__ == '__main__':
     # Master window
     windows.append(webview.create_window('Window #1', html='<h1>First window</h1><p>This one is static HTML and just uses the global server for api calls.</p>'))
     windows.append(webview.create_window('Window #2', url=app1))
-    webview.start(third_window,debug=True)
+    webview.start(third_window,debug=True,http_server=True)

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -132,9 +132,8 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
     has_local_urls = not not [
         w.original_url
         for w in windows
-        if is_app(w.original_url) or is_local_url(w.original_url)
+        if is_local_url(w.original_url)
     ]
-
     # start the global server if it's not running and we need it
     if (http.global_server is None) and \
         (http_server or has_local_urls or (guilib.renderer == 'gtkwebkit2')):

--- a/webview/window.py
+++ b/webview/window.py
@@ -124,7 +124,7 @@ class Window:
         if self.localization_override:
             self.localization.update(self.localization_override)
 
-        if needs_server([self.original_url]) and server is None:
+        if is_app(self.original_url) and (server is None or server == http.global_server):
             prefix, common_path, server = http.start_server(urls=[self.original_url], http_port=self._http_port, server=self._server, **self._server_args)
         elif server is None:
             server = http.global_server


### PR DESCRIPTION
Individual windows will now start a server only if their URL is a web app.

All other traffic goes to the global server.

Modified multiple_servers example to call start with http_server=True since the webapps will no longer cause the global server to be started. Also added some global server detection to the example so if http_server is set False the third window will correctly display that the global server is not started, instead of crashing.