### PR TITLE
[GTK] Require Soup 2.4 instead of 3.0 by default

### DIFF
--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -26,6 +26,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
 gi.require_version('WebKit2', '4.0')
+gi.require_version('Soup', '2.4')
 
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk


### PR DESCRIPTION
After the Soup library is updated to 3.0, other libraries still depend on the 2.4 version of Soup, but it imports the 3.0 Soup by default, which will cause the application to fail to start.

```
/usr/lib/python3.10/site-packages/webview/platforms/gtk.py:34: PyGIWarning: Soup was imported without specifying a version first. Use gi.require_version('Soup', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Soup
[pywebview] GTK cannot be loaded
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/gi/importer.py", line 142, in load_module
    introspection_module = get_introspection_module(namespace)
  File "/usr/lib/python3.10/site-packages/gi/module.py", line 257, in get_introspection_module
    module = IntrospectionModule(namespace, version)
  File "/usr/lib/python3.10/site-packages/gi/module.py", line 109, in __init__
    repository.require(namespace, version)
gi.RepositoryError: Requiring namespace 'Soup' version '2.4', but '3.0' is already loaded

During handling of the above exception, another exception occurred:
```

Importing version 2.4 of Soup by default can be used as a temporary solution.
