### PR TITLE
feat: macos supports manual switching of appearance

### DIFF
--- a/examples/set_theme.py
+++ b/examples/set_theme.py
@@ -1,0 +1,44 @@
+import random
+import sys
+import threading
+import time
+
+import webview
+
+"""
+This example demonstrates how to change the theme of the webview window
+"""
+
+html = """
+<!DOCTYPE html>
+<html>
+<body>
+
+
+<button onClick="setTheme('light')">light theme</button><br/>
+<button onClick="setTheme('dark')">dark theme</button><br/>
+<button onClick="setTheme('system')">system</button><br/>
+
+<script>
+    function setTheme(theme) {
+        pywebview.api.set_theme(theme)
+    }
+
+
+</script>
+</body>
+</html>
+"""
+
+
+class Api:
+    def set_theme(self,theme):
+        active_window = webview.active_window()
+        if active_window:
+            active_window.set_theme(theme)
+
+
+if __name__ == '__main__':
+    api = Api()
+    window = webview.create_window('API example',  html=html, js_api=api, transparent=True,vibrancy=True)
+    webview.start()

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -493,6 +493,14 @@ class BrowserView:
 
         AppHelper.callAfter(_set_title)
 
+    def set_theme(self, theme):
+        if theme == 'light':
+            self.window.setAppearance_(AppKit.NSAppearance.appearanceNamed_(AppKit.NSAppearanceNameVibrantLight))
+        elif theme == 'dark':
+            self.window.setAppearance_(AppKit.NSAppearance.appearanceNamed_(AppKit.NSAppearanceNameVibrantDark))
+        elif theme == 'system':
+            self.window.setAppearance_(None)
+
     def toggle_fullscreen(self):
         def toggle():
             if self.is_fullscreen:
@@ -871,6 +879,9 @@ def create_window(window):
     else:
         AppHelper.callAfter(create)
 
+def set_theme(theme, uid):
+    BrowserView.instances[uid].set_theme(theme)
+        
 
 def set_title(title, uid):
     BrowserView.instances[uid].set_title(title)

--- a/webview/window.py
+++ b/webview/window.py
@@ -228,7 +228,14 @@ class Window:
         Set a new title of the window
         """
         self.gui.set_title(title, self.uid)
-
+        
+    @_shown_call
+    def set_theme(self, theme):
+        """
+        Set a new theme of the window
+        """
+        self.gui.set_theme(theme, self.uid)
+        
     @_loaded_call
     def get_cookies(self):
         """


### PR DESCRIPTION
On macos, you can manually switch the appearance,  setting always light, always dark, or follow the system
such as WeChat:
<img width="301" alt="image" src="https://user-images.githubusercontent.com/31394482/215380401-bcc56df3-0134-49de-b4ea-c5da3adcea98.png">

### usage
```python
# theme： light, dark, system
window.set_theme(theme), 
```