### PR TITLE
SSL support for internal server

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -47,7 +47,7 @@ server=http.BottleServer, server_args
 ``` python
 webview.start(func=None, args=None, localization={}, gui=None, debug=False, http_server=False,
               http_port=None, user_agent=None, private_mode=True, storage_path=None, menu=[],
-              server=http.BottleServer, server_args={}):
+              server=http.BottleServer, ssl=False, server_args={}):
 ```
 
 Start a GUI loop and display previously created windows. This function must be called from a main thread.
@@ -64,6 +64,7 @@ Start a GUI loop and display previously created windows. This function must be c
 * `storage_path` - An optional location on hard drive where to store persistant objects. By default `~/.pywebview` is used  on *nix systems and `%APPDATA%\pywebview` on Windows.
 * `menu` - Pass a list of Menu objects to create an application menu. See [this example](/examples/menu.html) for usage details.
 * `server` - A custom WSGI server instance. Defaults to BottleServer.
+* `ssl` - If using the default BottleServer (and for now the GTK backend), will use SSL encryption between the webview and the internal server.
 * `server_args` - Dictionary of arguments to pass through to the server instantiation
 
 ### Examples

--- a/examples/localhost_ssl.py
+++ b/examples/localhost_ssl.py
@@ -1,0 +1,6 @@
+import webview
+
+if __name__ == '__main__':
+  webview.create_window('Local SSL Test', 'assets/index.html')
+  webview.start(ssl=True)
+

--- a/examples/localhost_ssl.py
+++ b/examples/localhost_ssl.py
@@ -2,5 +2,6 @@ import webview
 
 if __name__ == '__main__':
   webview.create_window('Local SSL Test', 'assets/index.html')
-  webview.start(ssl=True)
+  gui = 'qt' # or 'gtk'
+  webview.start(gui=gui, ssl=True)
 

--- a/examples/localhost_ssl.py
+++ b/examples/localhost_ssl.py
@@ -2,6 +2,6 @@ import webview
 
 if __name__ == '__main__':
   webview.create_window('Local SSL Test', 'assets/index.html')
-  gui = 'qt' # or 'gtk'
+  gui = None
   webview.start(gui=gui, ssl=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ QtPy; sys_platform == "openbsd6" or sys_platform == "linux"
 importlib_resources; python_version < "3.7"
 proxy_tools
 bottle
+cryptography

--- a/ssl.py
+++ b/ssl.py
@@ -1,6 +1,0 @@
-import webview
-
-if __name__ == '__main__':
-  webview.create_window('Local SSL Test', 'https://localhost/')
-  webview.start()
-

--- a/ssl.py
+++ b/ssl.py
@@ -1,0 +1,6 @@
+import webview
+
+if __name__ == '__main__':
+  webview.create_window('Local SSL Test', 'https://localhost/')
+  webview.start()
+

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -136,6 +136,8 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
       keyfile, certfile = generate_ssl_cert()
       server_args['keyfile'] = keyfile
       server_args['certfile'] = certfile
+    else:
+      keyfile, certfile = None, None
 
     urls = [w.original_url for w in windows]
     has_local_urls = not not [
@@ -173,7 +175,8 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
     guilib.set_app_menu(menu)
     guilib.create_window(windows[0])
     # keyfile is deleted by the ServerAdapter right after wrap_socket()
-    os.unlink(certfile)
+    if certfile:
+      os.unlink(certfile)
 
 
 def create_window(title, url=None, html=None, js_api=None, width=800, height=600, x=None, y=None,

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -156,8 +156,8 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
         window._initialize(guilib)
 
     if ssl:
-      for w in windows:
-        w.gui.add_tls_cert(certfile)
+      for window in windows:
+        window.gui.add_tls_cert(certfile)
 
     if len(windows) > 1:
         t = threading.Thread(target=_create_children, args=(windows[1:],))
@@ -264,7 +264,7 @@ def generate_ssl_cert():
           x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"California"),
           x509.NameAttribute(NameOID.LOCALITY_NAME, u"San Francisco"),
           x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"pywebview"),
-          x509.NameAttribute(NameOID.COMMON_NAME, u"pywebview.flowrl.com"),
+          x509.NameAttribute(NameOID.COMMON_NAME, u"127.0.0.1"),
       ])
       cert = x509.CertificateBuilder().subject_name(
           subject

--- a/webview/http.py
+++ b/webview/http.py
@@ -4,6 +4,7 @@ import logging
 import os
 import threading
 import random
+import ssl
 import socket
 import uuid
 
@@ -38,7 +39,7 @@ class BottleServer(object):
         self.uid = str(uuid.uuid1())
 
     @classmethod
-    def start_server(self, urls, http_port):
+    def start_server(self, urls, http_port, keyfile=None, certfile=None):
         from webview import _debug
 
         apps = [u for u in urls if is_app(u)]
@@ -77,15 +78,62 @@ class BottleServer(object):
 
         server.root_path = abspath(common_path) if common_path is not None else None
         server.port = http_port or _get_random_port()
-        server.thread = threading.Thread(target=lambda: bottle.run(app=app, port=server.port, quiet=not _debug['mode']), daemon=True)
+        if keyfile and certfile:
+          server_adapter = SSLWSGIRefServer()
+          server_adapter.port = server.port
+          setattr(server_adapter, 'pywebview_keyfile', keyfile)
+          setattr(server_adapter, 'pywebview_certfile', certfile)
+        else:
+         server_adapter = 'wsgiref'
+        server.thread = threading.Thread(target=lambda: bottle.run(app=app, server=server_adapter, port=server.port, quiet=not _debug['mode']), daemon=True)
         server.thread.start()
 
         server.running = True
-        server.address = f'http://127.0.0.1:{server.port}/'
+        protocol = 'https' if keyfile and certfile else 'http'
+        server.address = f'{protocol}://127.0.0.1:{server.port}/'
         self.common_path = common_path
         server.js_api_endpoint = f'{server.address}js_api/{server.uid}'
 
         return server.address, common_path, server
+
+class SSLWSGIRefServer(bottle.ServerAdapter):
+    def run(self, app):  # pragma: no cover
+        from wsgiref.simple_server import make_server
+        from wsgiref.simple_server import WSGIRequestHandler, WSGIServer
+        import socket
+
+        class FixedHandler(WSGIRequestHandler):
+            def address_string(self):  # Prevent reverse DNS lookups please.
+                return self.client_address[0]
+
+            def log_request(*args, **kw):
+                if not self.quiet:
+                    return WSGIRequestHandler.log_request(*args, **kw)
+
+        handler_cls = self.options.get('handler_class', FixedHandler)
+        server_cls = self.options.get('server_class', WSGIServer)
+
+        if ':' in self.host:  # Fix wsgiref for IPv6 addresses.
+            if getattr(server_cls, 'address_family') == socket.AF_INET:
+
+                class server_cls(server_cls):
+                    address_family = socket.AF_INET6
+
+        self.srv = make_server(self.host, self.port, app, server_cls,
+                               handler_cls)
+        context = ssl.create_default_context()
+        self.srv.socket = ssl.wrap_socket(
+                self.srv.socket,
+                keyfile=self.pywebview_keyfile,
+                certfile=self.pywebview_certfile,
+                server_side=True)
+        self.port = self.srv.server_port  # update port actual port (0 means random)
+        os.unlink(self.pywebview_keyfile)
+        try:
+            self.srv.serve_forever()
+        except KeyboardInterrupt:
+            self.srv.server_close()  # Prevent ResourceWarning: unclosed socket
+            raise
 
 
 def start_server(urls, http_port=None, server=BottleServer, **server_args):
@@ -93,7 +141,7 @@ def start_server(urls, http_port=None, server=BottleServer, **server_args):
     return server.start_server(urls, http_port, **server_args)
 
 
-def start_global_server(http_port=None, urls='.', server=BottleServer, **server_args):
+def start_global_server(http_port=None, urls='.', server=BottleServer, ssl=False, **server_args):
     global global_server
     address, common_path, global_server = start_server(urls=urls, http_port=http_port, server=server, **server_args)
     return address, common_path, global_server

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -137,6 +137,11 @@ class BrowserView:
                 handler.__block_signature__ = BrowserView.pyobjc_method_signature(b'v@')
             handler()
 
+        def webView_didReceiveAuthenticationChallenge_completionHandler_(self, webview, challenge, handler):
+            # this allows any server cert
+            credential = AppKit.NSURLCredential.credentialForTrust_(challenge.protectionSpace().serverTrust())
+            handler(AppKit.NSURLSessionAuthChallengeUseCredential, credential)
+
         # Display a JavaScript confirm panel containing the specified message
         def webView_runJavaScriptConfirmPanelWithMessage_initiatedByFrame_completionHandler_(self, webview, message, frame, handler):
             i = BrowserView.get_instance('webkit', webview)
@@ -357,6 +362,7 @@ class BrowserView:
         self.window.setFrame_display_(frame, True)
 
         self.webkit = BrowserView.WebKitHost.alloc().initWithFrame_(rect).retain()
+        print('self.webkit', self.webkit.__dict__)
 
         self._browserDelegate = BrowserView.BrowserDelegate.alloc().init().retain()
         self._windowDelegate = BrowserView.WindowDelegate.alloc().init().retain()
@@ -1098,4 +1104,10 @@ def get_size(uid):
 def get_screens():
     screens = [Screen(s.frame().size.width, s.frame().size.height) for s in AppKit.NSScreen.screens()]
     return screens
+
+
+def add_tls_cert(certfile):
+    # does not auth against the certfile
+    # see webView_didReceiveAuthenticationChallenge_completionHandler_
+    pass
 

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -362,7 +362,6 @@ class BrowserView:
         self.window.setFrame_display_(frame, True)
 
         self.webkit = BrowserView.WebKitHost.alloc().initWithFrame_(rect).retain()
-        print('self.webkit', self.webkit.__dict__)
 
         self._browserDelegate = BrowserView.BrowserDelegate.alloc().init().retain()
         self._windowDelegate = BrowserView.WindowDelegate.alloc().init().retain()

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -138,6 +138,9 @@ class BrowserView:
             handler()
 
         def webView_didReceiveAuthenticationChallenge_completionHandler_(self, webview, challenge, handler):
+            # Prevent `ObjCPointerWarning: PyObjCPointer created: ... type ^{__SecTrust=}`
+            from Security import SecTrustRef
+            
             # this allows any server cert
             credential = AppKit.NSURLCredential.credentialForTrust_(challenge.protectionSpace().serverTrust())
             handler(AppKit.NSURLSessionAuthChallengeUseCredential, credential)

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -131,6 +131,8 @@ class BrowserView:
             os.makedirs(storage_path)
 
         web_context = webkit.WebContext.get_default()
+        cert = Gio.TlsCertificate.new_from_file('/etc/ssl/certs/nginx-selfsigned.crt')
+        web_context.allow_tls_certificate_for_host(cert, 'localhost')
         self.cookie_manager = web_context.get_cookie_manager()
 
         if not _private_mode:

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -570,6 +570,12 @@ def toggle_fullscreen(uid):
     glib.idle_add(_toggle_fullscreen)
 
 
+def add_tls_cert(certfile):
+    web_context = webkit.WebContext.get_default()
+    cert = Gio.TlsCertificate.new_from_file(certfile)
+    web_context.allow_tls_certificate_for_host(cert, '127.0.0.1')
+
+
 def set_on_top(uid, top):
     def _set_on_top():
         BrowserView.instances[uid].window.set_keep_above(top)

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -131,8 +131,6 @@ class BrowserView:
             os.makedirs(storage_path)
 
         web_context = webkit.WebContext.get_default()
-        cert = Gio.TlsCertificate.new_from_file('/etc/ssl/certs/nginx-selfsigned.crt')
-        web_context.allow_tls_certificate_for_host(cert, 'localhost')
         self.cookie_manager = web_context.get_cookie_manager()
 
         if not _private_mode:

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -42,11 +42,13 @@ from qtpy import PYQT6, PYSIDE6
 try:
     from qtpy.QtWebEngineWidgets import QWebEngineView as QWebView, QWebEnginePage as QWebPage, QWebEngineProfile
     from qtpy.QtWebChannel import QWebChannel
+    from qtpy.QtNetwork import QSslConfiguration, QSslCertificate
     renderer = 'qtwebengine'
     is_webengine = True
 except ImportError:
     from PyQt5 import QtWebKitWidgets
     from PyQt5.QtWebKitWidgets import QWebView, QWebPage
+    from PyQt5.QtNetwork import QSslConfiguration, QSslCertificate
     is_webengine = False
     renderer = 'qtwebkit'
 
@@ -913,3 +915,12 @@ def get_screens():
     screens = [Screen(g.width(), g.height()) for g in geometries]
 
     return screens
+
+def add_tls_cert(certfile):
+    config = QSslConfiguration.defaultConfiguration()
+    certs = config.caCertificates()
+    cert = QSslCertificate.fromPath(certfile)[0]
+    certs.append(cert)
+    config.setCaCertificates(certs)
+    QSslConfiguration.setDefaultConfiguration(config)
+    

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -774,3 +774,7 @@ def get_size(uid):
 def get_screens():
     screens = [Screen(s.Bounds.Width, s.Bounds.Height) for s in WinForms.Screen.AllScreens]
     return screens
+
+def add_tls_cert(certfile):
+    raise NotImplementedError
+


### PR DESCRIPTION
I merged w/ your new threaded adapter, but this doesn't use it in SSL mode (yet).

This *only* supports the GTK backend ATM.  (I'm traveling, don't have access to test anything else ATM.)  Will look into the API for the others later.  I intentionally left it so it will fail (as `add_tls_cert()` won't exist) if you try to use it with another backend. 

This is quite a bit bigger than I anticipated.  I'm not familiar w/ bottle's internals, there may be a better way to wrap the socket w/ bottle mixins.

https://github.com/r0x0r/pywebview/issues/1034