### PR TITLE
Fix macOS crash: catch KeyError on `backspaceKeyNavigationEnabled`

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -386,11 +386,14 @@ class BrowserView:
             self.datastore = WebKit.WKWebsiteDataStore.defaultDataStore()
             config.setWebsiteDataStore_(self.datastore)
 
-        config.preferences().setValue_forKey_(Foundation.NO, 'backspaceKeyNavigationEnabled')
+        try:
+            config.preferences().setValue_forKey_(False, 'backspaceKeyNavigationEnabled')
+        except KeyError:
+            pass  # backspaceKeyNavigationEnabled does not exist prior to macOS Mojave
         config.preferences().setValue_forKey_(True, 'allowFileAccessFromFileURLs')
 
         if _debug['mode']:
-            config.preferences().setValue_forKey_(Foundation.YES, 'developerExtrasEnabled')
+            config.preferences().setValue_forKey_(True, 'developerExtrasEnabled')
 
         self.js_bridge = BrowserView.JSBridge.alloc().initWithObject_(window)
         config.userContentController().addScriptMessageHandler_name_(self.js_bridge, 'jsBridge')


### PR DESCRIPTION
On macOS versions prior to Mojave, setting `backspaceKeyNavigationEnabled` causes a crash because the key is not present.

This code was originally added in PR #294 (and this crash discussed in issue #210), but subsequently broken in b40511d. 

This change also switches from `Foundation.YES/NO` to `True/False` in two places for consistency with usage elsewhere.

Related: 'allowFileAccessFromFileURLs' was also protected with try/except prior to this change, but does not seem to actually need it.