### PR TITLE
Fix pywebview with PyInstaller or pythonw (caused by bottle.py)

### DIFF
--- a/webview/http.py
+++ b/webview/http.py
@@ -1,8 +1,20 @@
+import sys
+import tempfile
+
+
+if sys.platform == 'win32' and ('pythonw.exe' in sys.executable or getattr(sys, 'frozen', False)):
+    # bottle.py versions prior to 0.12.23 (the latest on PyPi as of Feb 2023) require stdout and
+    # stderr to exist, which is not the case on Windows with pythonw.exe or PyInstaller >= 5.8.0
+    if sys.stderr is None:
+        sys.stderr = tempfile.TemporaryFile()
+    if sys.stdout is None:
+        sys.stdout = tempfile.TemporaryFile()
+
+
 import bottle
 import json
 import logging
 import os
-import sys
 import threading
 import random
 import socket
@@ -45,19 +57,6 @@ class ThreadedAdapter(bottle.ServerAdapter):
 
         server = make_server(self.host, self.port, handler, server_class=ThreadAdapter, **self.options)
         server.serve_forever()
-
-
-class DummyLoggerWriter:
-    def __init__(self):
-        pass
-    def write(self, message):
-        pass
-    def flush(self):
-        pass
-
-if hasattr(sys, '_MEIPASS'): # Pyinstaller logging fix
-    sys.stdout = DummyLoggerWriter()
-    sys.stderr = DummyLoggerWriter()
 
 
 class BottleServer(object):


### PR DESCRIPTION
Bottle.py versions prior to 0.12.23 (the latest on PyPi as of Feb 2023) require stdout and stderr to exist when that package is imported, which is not the case on Windows when using pythonw.exe or PyInstaller >= 5.8.0.

This change is similar to the recently-merged PR #1038 that fixed #1029, but the fix in that PR only works if using bottle.py 0.13-dev, which is unlikely in most cases given that this version is not on PyPi (note that the fix it contains was committed over two years ago in January 2021).

This change uses a `TemporaryFile` instead of `DummyLogWriter` to resolve the issue. Fixes #1044.