### PR TITLE
Fix running tests in PowerShell when `__pycache__` doesn't exist

### DIFF
--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -49,7 +49,9 @@ $tests=@(
 #  $tests += "test_http_server.py"
 # }
 
-rm -r __pycache__
+if (Test-Path __pycache__) {
+  Remove-Item -Recurse -Force __pycache__
+}
 
 $errors = 0
 foreach ($test in $tests) {


### PR DESCRIPTION
A minor edit to the PowerShell test runner script to only attempt to remove `__pycache__` if it exists, avoiding an error.