### PR TITLE
Hide menu bar when there is no menu

### DIFF
--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -157,7 +157,8 @@ def start(func=None, args=None, localization={}, gui=None, debug=False, http_ser
             t = threading.Thread(target=func)
         t.start()
 
-    guilib.set_app_menu(menu)
+    if menu:
+        guilib.set_app_menu(menu)
     guilib.create_window(windows[0])
 
 


### PR DESCRIPTION
On Ubuntu 20, Python 3.11 with QT and GTK, when no menu is passed to the `webview.start()`, there is still an (ugly) menu bar being displayed:
![Screenshot from 2023-03-06 20-23-30](https://user-images.githubusercontent.com/17571457/223211519-9ff2b12e-cf76-461d-af24-de56d7a5cff2.png)

With this small fix, the `guilib.set_app_menu(menu)` get executed only if there is actually a menu to show. Resulting in:
![Screenshot from 2023-03-06 20-29-35](https://user-images.githubusercontent.com/17571457/223211669-9cd87180-0e08-429d-8eef-79ac0cf96c0e.png)
