### PR TITLE
Fix edgechromium cache

### DIFF
--- a/webview/platforms/edgechromium.py
+++ b/webview/platforms/edgechromium.py
@@ -49,7 +49,9 @@ class EdgeChrome:
         self.web_view = WebView2()
         props = CoreWebView2CreationProperties()
         props.UserDataFolder = cache_dir
+        props.set_IsInPrivateModeEnabled(_private_mode)
         self.web_view.CreationProperties = props
+
         form.Controls.Add(self.web_view)
 
         self.js_results = {}

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -186,7 +186,7 @@ class BrowserView:
                 self.frameless = window.frameless
                 self.FormBorderStyle = getattr(WinForms.FormBorderStyle, 'None')
 
-            if len(BrowserView.app_menu_list):
+            if BrowserView.app_menu_list:
                 self.set_window_menu(BrowserView.app_menu_list)
 
             if is_cef:

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -14,6 +14,7 @@ from threading import Event, Semaphore
 import ctypes
 from ctypes import windll
 from platform import machine
+import tempfile
 
 from webview import windows, _private_mode, _storage_path, OPEN_DIALOG, FOLDER_DIALOG, SAVE_DIALOG
 from webview.guilib import forced_gui_
@@ -127,7 +128,7 @@ if not _private_mode or _storage_path:
     except Exception as e:
         logger.exception(f'Cache directory {cache_dir} creation failed')
 else:
-    cache_dir = None
+    cache_dir = tempfile.TemporaryDirectory().name
 
 class BrowserView:
     instances = {}
@@ -135,7 +136,7 @@ class BrowserView:
     app_menu_list = None
 
     class BrowserForm(WinForms.Form):
-        def __init__(self, window):
+        def __init__(self, window, cache_dir):
             super().__init__()
             self.uid = window.uid
             self.pywebview_window = window
@@ -522,7 +523,7 @@ def setup_app():
 
 def create_window(window):
     def create():
-        browser = BrowserView.BrowserForm(window)
+        browser = BrowserView.BrowserForm(window,cache_dir)
         BrowserView.instances[window.uid] = browser
 
         if window.hidden:


### PR DESCRIPTION
This PR solves two bugs described in #1081.

### first bug

an uninitialized list was checked for its length.

### second bug

`_private_mode` is `True` by default. This causes `cache_dir` to be `None` by default in `winforms.py`
Webview2 crashes if no `UserDataFolder` exists.

To solve this issue, pythons `tempfile.TemporaryDirectory` is used to set `cache_dir` to a temporary directory.

Actually, I wanted to use `TemporaryDirectory` context manager to auto delete the created directory, after window is closed.
Unfortunately, the process still accesses some of the files and blocks the deletion process. A `sleep(1)` solves this issue, but that's a dirty solution.