### PR TITLE
Disable touchpad elastic overscroll by default for Edge/Webview2 on Windows

### DIFF
--- a/webview/platforms/edgechromium.py
+++ b/webview/platforms/edgechromium.py
@@ -41,6 +41,7 @@ class EdgeChrome:
         props = CoreWebView2CreationProperties()
         props.UserDataFolder = cache_dir
         props.set_IsInPrivateModeEnabled(_private_mode)
+        props.AdditionalBrowserArguments = '--disable-features=ElasticOverscroll'
         self.web_view.CreationProperties = props
 
         form.Controls.Add(self.web_view)


### PR DESCRIPTION
Fixes #1118. Note that I have not attempted to create a mechanism to re-enable this feature through the `webview` interface, partly because it's platform-specific.

It may be interesting in the future to allow the user to pass arguments to `AdditionalBrowserArguments`, but a cross platform solution/mechanism presumably needs to be devised for that purpose. I'm not familiar enough with the Linux and Mac interfaces enough to determine whether adding a `window_args`  might make sense.