### PR TITLE
Remove stated limit of Python 3.8 for Windows from Read Me

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ _pywebview_ is created by [Roman Sirokov](https://github.com/r0x0r/).
 ``` bash
 pip install pywebview
 ```
-- _Currently only python version 3.8 or older supported on Windows._
 - _On Linux you need additional libraries. Refer to the [installation](https://pywebview.flowrl.com/guide/installation.html) page for details._
 
 


### PR DESCRIPTION
Remove stated limit of Python 3.8 for Windows from Read Me. Python 3.9 and above have been supported on Windows since the release of pythonnet 3.