### PR TITLE
Add missing macOS dependency (fix crash in pywebview 4.1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pythonnet; sys_platform == "win32"
 pyobjc-core; sys_platform == "darwin"
 pyobjc-framework-Cocoa; sys_platform == "darwin"
+pyobjc-framework-Security; sys_platform == "darwin"
 pyobjc-framework-WebKit; sys_platform == "darwin"
 PyQt5; sys_platform == "openbsd6" or sys_platform == "linux"
 pyqtwebengine; sys_platform == "openbsd6" or sys_platform == "linux"


### PR DESCRIPTION
df72ac1 added a new import to address a console warning on macOS, but did not add the corresponding requirement `pyobjc-framework-Security`. As a result, pywebview 4.1 crashes on macOS with the following message: `*** Terminating app due to uncaught exception 'OC_PythonException', reason: '<class 'ModuleNotFoundError'>: No module named 'Security''`.

Installing `pyobjc-framework-Security` fixes this issue.