### PR TITLE
[GTK] Fix closing event handlers cancellation

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -382,7 +382,7 @@ Event fired just before pywebview window is closed.
 [Example](/examples/events.html)
 
 ## events.closing
-Event fired when pywebview window is about to be closed. If confirm_quit is set, then this event is fired before the close confirmation is displayed. If event handler returns False, the close operation will be cancelled.
+Event fired when pywebview window is about to be closed. If confirm_close is set, then this event is fired before the close confirmation is displayed. If event handler returns False, the close operation will be cancelled.
 
 [Example](/examples/events.html)
 

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -195,7 +195,7 @@ class BrowserView:
         should_cancel = self.pywebview_window.events.closing.set()
 
         if should_cancel:
-            return
+            return True
 
         for res in self.js_results.values():
             res['semaphore'].release()
@@ -208,6 +208,8 @@ class BrowserView:
 
         self.pywebview_window.events.closed.set()
 
+        return False
+
     def on_destroy(self, widget=None, *data):
         dialog = gtk.MessageDialog(
             parent=self.window,
@@ -217,11 +219,12 @@ class BrowserView:
             message_format=self.localization['global.quitConfirmation'],
         )
         result = dialog.run()
+        should_cancel = True
         if result == gtk.ResponseType.OK:
-            self.close_window()
+            should_cancel = self.close_window()
 
         dialog.destroy()
-        return True
+        return should_cancel
 
     def on_window_state_change(self, window, window_state):
         if window_state.changed_mask == Gdk.WindowState.ICONIFIED:


### PR DESCRIPTION
This simple fix allows users to prevent window closing from `closing` event handlers even if `confirm_close` is not set.