### PR TITLE
[GTK] closing event working as documented

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -382,7 +382,7 @@ Event fired just before pywebview window is closed.
 [Example](/examples/events.html)
 
 ## events.closing
-Event fired when pywebview window is about to be closed. If confirm_quit is set, then this event is fired before the close confirmation is displayed. If event handler returns False, the close operation will be cancelled.
+Event fired when pywebview window is about to be closed. If confirm_close is set, then this event is fired before the close confirmation is displayed. If event handler returns False, the close operation will be cancelled.
 
 [Example](/examples/events.html)
 

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -195,7 +195,7 @@ class BrowserView:
         should_cancel = self.pywebview_window.events.closing.set()
 
         if should_cancel:
-            return
+            return True
 
         for res in self.js_results.values():
             res['semaphore'].release()
@@ -208,6 +208,8 @@ class BrowserView:
 
         self.pywebview_window.events.closed.set()
 
+        return False
+
     def on_destroy(self, widget=None, *data):
         dialog = gtk.MessageDialog(
             parent=self.window,
@@ -217,11 +219,12 @@ class BrowserView:
             message_format=self.localization['global.quitConfirmation'],
         )
         result = dialog.run()
+        should_cancel = True
         if result == gtk.ResponseType.OK:
-            self.close_window()
+            should_cancel = self.close_window()
 
         dialog.destroy()
-        return True
+        return should_cancel
 
     def on_window_state_change(self, window, window_state):
         if window_state.changed_mask == Gdk.WindowState.ICONIFIED:

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -217,7 +217,7 @@ class BrowserView:
             windows.remove(self.pywebview_window)
 
         self.pywebview_window.events.closed.set()
-        
+
         return False
 
     def on_window_state_change(self, window, window_state):

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -104,10 +104,7 @@ class BrowserView:
         scrolled_window = gtk.ScrolledWindow()
         self.window.add(scrolled_window)
 
-        if window.confirm_close:
-            self.window.connect('delete-event', self.on_destroy)
-        else:
-            self.window.connect('delete-event', self.close_window)
+        self.window.connect('delete-event', self.close_window)
 
         self.window.connect('window-state-event', self.on_window_state_change)
         self.window.connect('size-allocate', self.on_window_resize)
@@ -196,6 +193,19 @@ class BrowserView:
 
         if should_cancel:
             return True
+        
+        if self.pywebview_window.confirm_close:
+            dialog = gtk.MessageDialog(
+                parent=self.window,
+                flags=gtk.DialogFlags.MODAL & gtk.DialogFlags.DESTROY_WITH_PARENT,
+                type=gtk.MessageType.QUESTION,
+                buttons=gtk.ButtonsType.OK_CANCEL,
+                message_format=self.localization['global.quitConfirmation'],
+            )
+            result = dialog.run()
+            dialog.destroy()
+            if result == gtk.ResponseType.CANCEL:
+                return True
 
         for res in self.js_results.values():
             res['semaphore'].release()
@@ -207,24 +217,8 @@ class BrowserView:
             windows.remove(self.pywebview_window)
 
         self.pywebview_window.events.closed.set()
-
+        
         return False
-
-    def on_destroy(self, widget=None, *data):
-        dialog = gtk.MessageDialog(
-            parent=self.window,
-            flags=gtk.DialogFlags.MODAL & gtk.DialogFlags.DESTROY_WITH_PARENT,
-            type=gtk.MessageType.QUESTION,
-            buttons=gtk.ButtonsType.OK_CANCEL,
-            message_format=self.localization['global.quitConfirmation'],
-        )
-        result = dialog.run()
-        should_cancel = True
-        if result == gtk.ResponseType.OK:
-            should_cancel = self.close_window()
-
-        dialog.destroy()
-        return should_cancel
 
     def on_window_state_change(self, window, window_state):
         if window_state.changed_mask == Gdk.WindowState.ICONIFIED:


### PR DESCRIPTION
This is what I view as a complete fix for the closing event beahvior under GTK. I did a separate pull request from a smaller fix because I'm not sure this one is wanted: maybe the documentation is wrong and the code was right.

What this does is to actually run the `events.closing` handlers _before_ the closing confirmation (if `confirm_close` is set), as explained in the documentation (see issue #1178).

It also simplifies the GTK code by merging the `close_window` and `on_destroy` functions, in the spirit of how it is done in the Qt code.

Maybe the new merged function should rather be called `on_window_close` to match other event handlers. But that's not really for me to decide :).

-----

As a bonus, it also looks up the value of the `confirm_close` property on the pywebview window at event time rather than initialization time, so that this can be dynamically changed (see the first comment of issue #1178).

This new behavior should be backward compatible with the previous one except if some code exists that changed the value of the `confirm_close` property of their pywebview windows with no effect previously (but why would anyone do that?).

However, this new behavior will differ on other backend as is, as I could only test it with GTK so that's the only one I changed in this PR. But note that changing this behavior for other backends as well should be very straightforward since they all have access to the pywebview window.