### PR TITLE
Update closing event behavior to match GTK behavior in PR #1180

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -382,7 +382,7 @@ Event fired just before pywebview window is closed.
 [Example](/examples/events.html)
 
 ## events.closing
-Event fired when pywebview window is about to be closed. If confirm_quit is set, then this event is fired before the close confirmation is displayed. If event handler returns False, the close operation will be cancelled.
+Event fired when pywebview window is about to be closed. If confirm_close is set, then this event is fired before the close confirmation is displayed. If event handler returns False, the close operation will be cancelled.
 
 [Example](/examples/events.html)
 

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -911,14 +911,12 @@ class BrowserView:
         cancel = window.localization['global.cancel']
         msg = window.localization['global.quitConfirmation']
 
-        if not window.confirm_close or BrowserView.display_confirmation_dialog(quit, cancel, msg):
-            should_cancel = window.events.closing.set()
-            if should_cancel:
-                return Foundation.NO
-            else:
-                return Foundation.YES
-        else:
+        should_cancel = window.events.closing.set()
+        if should_cancel:
             return Foundation.NO
+        if not window.confirm_close or BrowserView.display_confirmation_dialog(quit, cancel, msg):
+            return Foundation.YES
+        return Foundation.NO
 
     @staticmethod
     def print_webview(webview):

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -195,7 +195,7 @@ class BrowserView:
         should_cancel = self.pywebview_window.events.closing.set()
 
         if should_cancel:
-            return
+            return True
 
         for res in self.js_results.values():
             res['semaphore'].release()
@@ -208,6 +208,8 @@ class BrowserView:
 
         self.pywebview_window.events.closed.set()
 
+        return False
+
     def on_destroy(self, widget=None, *data):
         dialog = gtk.MessageDialog(
             parent=self.window,
@@ -217,11 +219,12 @@ class BrowserView:
             message_format=self.localization['global.quitConfirmation'],
         )
         result = dialog.run()
+        should_cancel = True
         if result == gtk.ResponseType.OK:
-            self.close_window()
+            should_cancel = self.close_window()
 
         dialog.destroy()
-        return True
+        return should_cancel
 
     def on_window_state_change(self, window, window_state):
         if window_state.changed_mask == Gdk.WindowState.ICONIFIED:

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -217,7 +217,7 @@ class BrowserView:
             windows.remove(self.pywebview_window)
 
         self.pywebview_window.events.closed.set()
-        
+
         return False
 
     def on_window_state_change(self, window, window_state):

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -104,10 +104,7 @@ class BrowserView:
         scrolled_window = gtk.ScrolledWindow()
         self.window.add(scrolled_window)
 
-        if window.confirm_close:
-            self.window.connect('delete-event', self.on_destroy)
-        else:
-            self.window.connect('delete-event', self.close_window)
+        self.window.connect('delete-event', self.close_window)
 
         self.window.connect('window-state-event', self.on_window_state_change)
         self.window.connect('size-allocate', self.on_window_resize)
@@ -196,6 +193,19 @@ class BrowserView:
 
         if should_cancel:
             return True
+        
+        if self.pywebview_window.confirm_close:
+            dialog = gtk.MessageDialog(
+                parent=self.window,
+                flags=gtk.DialogFlags.MODAL & gtk.DialogFlags.DESTROY_WITH_PARENT,
+                type=gtk.MessageType.QUESTION,
+                buttons=gtk.ButtonsType.OK_CANCEL,
+                message_format=self.localization['global.quitConfirmation'],
+            )
+            result = dialog.run()
+            dialog.destroy()
+            if result == gtk.ResponseType.CANCEL:
+                return True
 
         for res in self.js_results.values():
             res['semaphore'].release()
@@ -207,24 +217,8 @@ class BrowserView:
             windows.remove(self.pywebview_window)
 
         self.pywebview_window.events.closed.set()
-
+        
         return False
-
-    def on_destroy(self, widget=None, *data):
-        dialog = gtk.MessageDialog(
-            parent=self.window,
-            flags=gtk.DialogFlags.MODAL & gtk.DialogFlags.DESTROY_WITH_PARENT,
-            type=gtk.MessageType.QUESTION,
-            buttons=gtk.ButtonsType.OK_CANCEL,
-            message_format=self.localization['global.quitConfirmation'],
-        )
-        result = dialog.run()
-        should_cancel = True
-        if result == gtk.ResponseType.OK:
-            should_cancel = self.close_window()
-
-        dialog.destroy()
-        return should_cancel
 
     def on_window_state_change(self, window, window_state):
         if window_state.changed_mask == Gdk.WindowState.ICONIFIED:

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -237,7 +237,6 @@ class BrowserView(QMainWindow):
         self.js_bridge.window = window
 
         self.is_fullscreen = False
-        self.confirm_close = window.confirm_close
         self.text_select = window.text_select
 
         self._file_name_semaphore = Semaphore(0)
@@ -456,7 +455,13 @@ class BrowserView(QMainWindow):
         self.show()
 
     def closeEvent(self, event):
-        if self.confirm_close:
+        should_cancel = self.pywebview_window.events.closing.set()
+
+        if should_cancel:
+            event.ignore()
+            return
+
+        if self.pywebview_window.confirm_close:
             reply = QMessageBox.question(
                 self,
                 self.title,
@@ -468,12 +473,6 @@ class BrowserView(QMainWindow):
             if reply == QMessageBox.No:
                 event.ignore()
                 return
-
-        should_cancel = self.pywebview_window.events.closing.set()
-
-        if should_cancel:
-            event.ignore()
-            return
 
         event.accept()
         BrowserView.instances[self.uid].close()

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -279,22 +279,21 @@ class BrowserView:
                 self.Invoke(Func[Type](_shutdown))
 
         def on_closing(self, sender, args):
-            if self.pywebview_window.confirm_close:
-                result = WinForms.MessageBox.Show(
-                    self.localization['global.quitConfirmation'],
-                    self.Text,
-                    WinForms.MessageBoxButtons.OKCancel,
-                    WinForms.MessageBoxIcon.Asterisk,
-                )
-
-                if result == WinForms.DialogResult.Cancel:
-                    args.Cancel = True
+            should_cancel = self.closing.set()
+            if should_cancel:
+                args.Cancel = True
 
             if not args.Cancel:
-                should_cancel = self.closing.set()
+                if self.pywebview_window.confirm_close:
+                    result = WinForms.MessageBox.Show(
+                        self.localization['global.quitConfirmation'],
+                        self.Text,
+                        WinForms.MessageBoxButtons.OKCancel,
+                        WinForms.MessageBoxIcon.Asterisk,
+                    )
 
-                if should_cancel:
-                    args.Cancel = True
+                    if result == WinForms.DialogResult.Cancel:
+                        args.Cancel = True
 
         def on_resize(self, sender, args):
             if self.WindowState == WinForms.FormWindowState.Maximized:


### PR DESCRIPTION
This is a sibling PR to #1180, but update Qt, Cocoa, and Windows platforms in addition to GTK. The goal is to make the implementation follow the documentation which states that window closing event handlers are called before the closing confirmation dialog (in the case `confirm_close` is set).

I made it a separate PR because even though the changes are quite straightforward and should not cause any problems, _**I have not tested them**_. I do not have a Windows nor a Mac, and the Qt platform does not work for me (I'm using KDE but strangely, attempting to use Qt with pywebview fails, it only show a blank window, that's why I work using GTK).

So, these have to be tested by someone before they get merged!

Here is a simple test program:

```python
import time
import webview

prevent_closing = True

def on_closing ():
    global prevent_closing
    return not prevent_closing

def test (window):
    global prevent_closing
    print("prevent closing for 5s")
    time.sleep(5)
    prevent_closing = False
    print("can now close, but confirmation required for 5s")
    time.sleep(5)
    window.confirm_close = False
    print("can now close without confirmation")

window = webview.create_window('Test PR #1181', confirm_close=True)
window.events.closing += on_closing
webview.start(test, window)
```