### PR TITLE
[GTK] SEGFAULT on Second 'webview.start()' Call

### DIFF
--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -524,6 +524,7 @@ def create_window(window):
     if window.uid == 'master':
         _app.connect('activate', create_master_callback)
         _app.run()
+        _app = None
     else:
         # _app will already have been activated by this point
         glib.idle_add(create)


### PR DESCRIPTION
This should fix issue #1063 (never solved despite being marked as 'complete').

## The Source of the Problem
After coming across this error in my own work, debugging to the source, and looking at GTK's source code for the relevant area, I found a solution. If the `global _app` variable is `run()` for a second time, then an assertion in GTK will be triggered. This assertion protects an application from having its arguments parsed more than one time and is necessary due to the way that GTK handles parsing arguments. 

https://github.com/GNOME/glib/blob/main/gio/gapplication.c#L493-L497

## The Solution
The solution to this is to create a new app every time `webview.start()` is called. Currently the app is created under the condition that it is `None` when `webview.start()` is called. Given that the app has already been run at least once, that condition will never be `True` again. Adding `_app = None` directly after `_app.run()` will delete the old app and also cause a new one to be created when `webview.start()` is called again. This solves the problem.

## Credit
This solution was already proposed by @bismarckkk. I simply researched it and opened this pull request for it. If this solution is flawed please let me know. I am willing to put some work into this.