### PR TITLE
Add no sandbox for arch/manjaro/nixos to avoid white screen problem

### DIFF
--- a/webview/util.py
+++ b/webview/util.py
@@ -309,3 +309,14 @@ def interop_dll_path(dll_name: str) -> str:
         pass
 
     raise FileNotFoundError(f'Cannot find {dll_name}')
+
+
+def environ_append(key: str, *values: str, sep=' ') -> None:
+    '''Append values to an environment variable, separated by sep'''
+    values = list(values)
+    
+    existing = os.environ.get(key, '')
+    if existing:
+        values = [existing] + values
+
+    os.environ[key] = sep.join(values)


### PR DESCRIPTION
I don't know why, but it's a common solution for #890 (White screen displayed)
such as: 

- https://github.com/LCA-ActivityBrowser/activity-browser/pull/954
- https://bugs.archlinux.org/task/73957
- https://www.google.com/search?q=arch+rstudio+no+sandbox

And sometimes it needs two "--no-sandbox" flags
