### PR TITLE
Monitor selection for Qt, Gtk, and Cocoa

### DIFF
--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -229,6 +229,7 @@ def create_window(
     server: type[http.ServerType] = http.BottleServer,
     http_port: int | None = None,
     server_args: http.ServerArgs = {},
+    screen: Screen = None,
 ) -> Window:
     """
     Create a web view window using a native GUI. The execution blocks after this function is invoked, so other
@@ -252,6 +253,7 @@ def create_window(
     :param transparent: Don't draw window background.
     :param server: Server class. Defaults to BottleServer
     :param server_args: Dictionary of arguments to pass through to the server instantiation
+    :param screen: Screen to display the window upon.
     :return: window object.
     """
 
@@ -292,6 +294,7 @@ def create_window(
         server=server,
         http_port=http_port,
         server_args=server_args,
+        screen=screen,
     )
 
     windows.append(window)

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -73,6 +73,11 @@ class BrowserView:
         self._last_width = window.initial_width
         self._last_height = window.initial_height
 
+        if window.screen:
+            self.screen = window.screen.frame
+        else:
+            self.screen = Gdk.Screen.get_default().get_monitor_geometry(0)
+
         if window.resizable:
             self.window.set_size_request(window.min_size[0], window.min_size[1])
             self.window.resize(window.initial_width, window.initial_height)
@@ -87,7 +92,10 @@ class BrowserView:
         if window.initial_x is not None and window.initial_y is not None:
             self.move(window.initial_x, window.initial_y)
         else:
-            self.window.set_position(gtk.WindowPosition.CENTER)
+            window_width, window_height = self.window.get_size()
+            x = (self.screen.width - window_width) // 2
+            y = (self.screen.height - window_height) // 2
+            self.move(x, y)
 
         self.window.set_resizable(window.resizable)
         self.window.set_accept_focus(window.focus)
@@ -193,7 +201,7 @@ class BrowserView:
 
         if should_cancel:
             return True
-        
+
         if self.pywebview_window.confirm_close:
             dialog = gtk.MessageDialog(
                 parent=self.window,
@@ -337,7 +345,7 @@ class BrowserView:
         self.window.resize(width, height)
 
     def move(self, x, y):
-        self.window.move(x, y)
+        self.window.move(self.screen.x+x, self.screen.y+y)
 
     def minimize(self):
         glib.idle_add(self.window.iconify)
@@ -775,7 +783,7 @@ def get_screens():
     screen = Gdk.Screen.get_default()
     n = screen.get_n_monitors()
     geometries = [screen.get_monitor_geometry(i) for i in range(n)]
-    screens = [Screen(geom.width, geom.height) for geom in geometries]
+    screens = [Screen(geom.width, geom.height, geom) for geom in geometries]
 
     return screens
 

--- a/webview/screen.py
+++ b/webview/screen.py
@@ -1,7 +1,8 @@
 class Screen:
-    def __init__(self, width: int, height: int) -> None:
+    def __init__(self, width: int, height: int, frame: object = None) -> None:
         self.width = int(width)
         self.height = int(height)
+        self.frame = frame
 
     def __str__(self) -> str:
         return repr(self)

--- a/webview/window.py
+++ b/webview/window.py
@@ -17,6 +17,7 @@ from webview.event import Event
 from webview.localization import original_localization
 from webview.util import (WebViewException, base_uri, escape_string, is_app, is_local_url,
                           parse_file_type)
+from .screen import Screen
 
 from .js import css
 
@@ -113,6 +114,7 @@ class Window:
         http_port: int | None = None,
         server: type[http.ServerType] | None = None,
         server_args: http.ServerArgs = {},
+        screen: Screen = None
     ) -> None:
         self.uid = uid
         self.title = title
@@ -141,6 +143,7 @@ class Window:
         self.draggable = draggable
         self.localization_override = localization
         self.vibrancy = vibrancy
+        self.screen = screen
 
         # Server config
         self._http_port = http_port


### PR DESCRIPTION
This PR (#1186) introduces support for monitor selection for libraries Qt, Gtk and Cocoa, using the `screen` parameter of `create_window`, by passing it a `Screen` object:

```python
screens = webview.screens

window = webview.create_window('', html='placed on the first monitor', screen=screens[0])
window = webview.create_window('', html='placed on the second monitor', screen=screens[1])

webview.start()
```

I have tested Qt and Cocoa, and they appear to work perfectly, however I have been unable to test the Gtk integration (linux only).

I also left out support for winforms, as `webview.screens` has not yet been implemented for this.