### PR TITLE
Fix docs virtualenv link

### DIFF
--- a/docs/guide/virtualenv.md
+++ b/docs/guide/virtualenv.md
@@ -1,6 +1,6 @@
 # Virtual environment
 
-If you create a virtual environment using the built-in Python on macOS, a pywebview window will have issues  with keyboard focus and Cmd+Tab. The issue can be avoided by using other Python installation as described [here](https://virtualenv.pypa.io/en/stable/userguide/#using-virtualenv-without-bin-python). For example to use Python 3 via [Homebrew](https://brew.sh).
+If you create a virtual environment using the built-in Python on macOS, a pywebview window will have issues  with keyboard focus and Cmd+Tab. The issue can be avoided by using other Python installation as described [here](https://virtualenv.pypa.io/en/latest/user_guide.html#python-discovery). For example to use Python 3 via [Homebrew](https://brew.sh).
 
 ``` bash
 brew install python3


### PR DESCRIPTION
This change updates the dead link in the documentation related to virtuelenv as described in #1220.