### PR TITLE
[GTK] Bump WebKit2 to 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ matrix:
       python: "3.6_with_system_site_packages"
     - os: linux
       sudo: required
-      dist: xenial
+      dist: jammy
       env:
-        - PACKAGES="xvfb gir1.2-gtk-3.0 gir1.2-webkit2-4.0 python3-gi python3-gi-cairo python3-pep8 pyflakes python3-pytest python3-six" PYTHON="python3"
+        - PACKAGES="xvfb gir1.2-gtk-3.0 gir1.2-webkit2-4.1 python3-gi python3-gi-cairo python3-pep8 pyflakes3 python3-pytest python3-six" PYTHON="python3"
     - os: linux
       sudo: required
       dist: xenial

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -48,7 +48,7 @@ You can also use QT5 in macOS
 [PyGObject](https://pygobject.readthedocs.io/en/latest/) is used with GTK. To install dependencies on Ubuntu for both Python 3 and 2
 
 ``` bash
-sudo apt install python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-webkit2-4.0
+sudo apt install python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-webkit2-4.1
 ```
 
 For other distributions, consult the [PyGObject documentation](https://pygobject.readthedocs.io/en/latest/getting_started.html)

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -21,8 +21,8 @@ import gi
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
-gi.require_version('WebKit2', '4.0')
-gi.require_version('Soup', '2.4')
+gi.require_version('WebKit2', '4.1')
+gi.require_version('Soup', '3.0')
 
 from gi.repository import Gdk, Gio
 from gi.repository import GLib as glib


### PR DESCRIPTION
According to "WebKitGTK API for GTK 4 Is Now Stable" [1], webkit2gtk-4.0 is obsolete and users should immediately port to webkit2gtk-4.1. Besides, webkit2gtk-4.1 using GTK 3 and libsoup 3 has become the default API version in WebKitGTK 2.40 [2].

The GNOME 44(+) flatpak runtimes have already dropped webkit2gtk-4.0:
```
$ flatpak run --command=find org.gnome.Platform//44 /lib/x86_64-linux-gnu/ -name libwebkit*
/lib/x86_64-linux-gnu/webkitgtk-6.0/injected-bundle/libwebkitgtkinjectedbundle.so
/lib/x86_64-linux-gnu/libwebkitgtk-6.0.so.4
/lib/x86_64-linux-gnu/libwebkit2gtk-4.1.so.0.12.4
/lib/x86_64-linux-gnu/libwebkit2gtk-4.1.so.0
/lib/x86_64-linux-gnu/libwebkitgtk-6.0.so.4.4.4
/lib/x86_64-linux-gnu/webkit2gtk-4.1/injected-bundle/libwebkit2gtkinjectedbundle.so
```
PS. GNOME 43 flatpak runtime has been end-of-life.

And, most Linux distributions support WebKit2 4.1 now.
* Arch Linux: https://archlinux.org/packages/?sort=&q=webkit2gtk&maintainer=&flagged=
* Alpine: https://pkgs.alpinelinux.org/packages?name=webkit2gtk*&branch=v3.18&repo=&arch=&maintainer=
* Debian: https://packages.debian.org/search?keywords=webkit2gtk
* Ubuntu: https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=webkit2gtk&searchon=names
* Fedora: https://packages.fedoraproject.org/pkgs/webkitgtk/
* ...

[1]: https://blogs.gnome.org/mcatanzaro/2023/03/21/webkitgtk-api-for-gtk-4-is-now-stable/
[2]: https://github.com/WebKit/WebKit/blob/wpewebkit-2.40.0/Source/cmake/OptionsGTK.cmake#L232-L235