### PR TITLE
Enable access to local-files when using file:// uris on omitted platforms.

### DIFF
--- a/webview/platforms/edgechromium.py
+++ b/webview/platforms/edgechromium.py
@@ -41,7 +41,7 @@ class EdgeChrome:
         props = CoreWebView2CreationProperties()
         props.UserDataFolder = cache_dir
         props.set_IsInPrivateModeEnabled(_settings['private_mode'])
-        props.AdditionalBrowserArguments = '--disable-features=ElasticOverscroll'
+        props.AdditionalBrowserArguments = '--disable-features=ElasticOverscroll --allow-file-access-from-files'
         self.web_view.CreationProperties = props
 
         form.Controls.Add(self.web_view)

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -153,6 +153,7 @@ class BrowserView:
         webkit_settings.enable_webaudio = True
         webkit_settings.enable_webgl = True
         webkit_settings.javascript_can_access_clipboard = True
+        webkit_settings.allow_file_access_from_file_urls = True
 
         if window.frameless:
             self.window.set_decorated(False)

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -33,7 +33,7 @@ try:
     from qtpy.QtNetwork import QSslCertificate, QSslConfiguration
     from qtpy.QtWebChannel import QWebChannel
     from qtpy.QtWebEngineWidgets import QWebEnginePage as QWebPage
-    from qtpy.QtWebEngineWidgets import QWebEngineProfile
+    from qtpy.QtWebEngineWidgets import QWebEngineProfile, QWebEngineSettings
     from qtpy.QtWebEngineWidgets import QWebEngineView as QWebView
 
     renderer = 'qtwebengine'
@@ -348,6 +348,10 @@ class BrowserView(QMainWindow):
                 self.view.setPage(BrowserView.WebPage(self.view, profile=self.profile))
         elif not is_webengine and not _settings['private_mode']:
             logger.warning('qtwebkit does not support private_mode')
+
+        if is_webengine:
+            self.profile.settings().setAttribute(
+                QWebEngineSettings.LocalContentCanAccessFileUrls, True)
 
         self.view.page().loadFinished.connect(self.on_load_finished)
         self.setCentralWidget(self.view)


### PR DESCRIPTION
It enables access to `file://` paths when on `file://` loaded page. It does not allow to access `file://` when using remote or built-in http server.
For supported platforms, QT - going by their docs - seems to enable it by default and Cocoa has in enabled explicitly. Seems that only GTK and Edge are omitted.

I'm not sure if it would be better to have it as an option, but then if defaulted to False things could stop working for people on Mac and QT. So enabling it at least should give same behavior everywhere.

Similar (same?) to https://github.com/r0x0r/pywebview/issues/1013.
