### PR TITLE
[GTK] Fix WebKit 4.0 as fallback

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ for:
       PYWEBVIEW_GUI: gtk
     install:
       - sudo apt-get update -q
-      - sudo apt-get install --no-install-recommends -y xvfb gir1.2-gtk-3.0 gir1.2-webkit2-4.1 python3-gi python3-gi-cairo python3-pep8 pyflakes3 python3-pytest python3-six
+      - sudo apt-get install --no-install-recommends -y xvfb gir1.2-gtk-3.0 gir1.2-webkit2-4.0 python3-gi python3-gi-cairo python3-pep8 pyflakes3 python3-pytest python3-six
       - python3 -m pip install proxy_tools pytest bottle typing_extensions pygobject
     before_test:
       - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset && sleep 3;

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -27,8 +27,8 @@ try:
     gi.require_version('Soup', '3.0')
 except ValueError:
     logger.debug('WebKit2 4.1 not found. Using 4.0.')
-    gi.require_version('WebKit2', '4.1')
-    gi.require_version('Soup', '3.0')
+    gi.require_version('WebKit2', '4.0')
+    gi.require_version('Soup', '2.4')
 
 from gi.repository import Gdk, Gio
 from gi.repository import GLib as glib


### PR DESCRIPTION
Some Linux OS versions have not included WekKit 4.1, such as Ubuntu 20.04. Fix the Webkit 4.0 and Soup 2.4 as the fallback.

Fixes commit 34432a3bc8a3 ("[GTK] Fallback for Webkit4.1")