### PR TITLE
Avoid test a web page needing GBM device

### DIFF
--- a/tests/test_multi_window.py
+++ b/tests/test_multi_window.py
@@ -106,5 +106,5 @@ def load_html(window):
 def load_url(window):
     child_window = webview.create_window('Window #2')
     assert child_window != 'MainWindow'
-    child_window.load_url('https://woot.fi')
+    child_window.load_url('https://pywebview.flowrl.com')
     child_window.destroy()

--- a/tests/test_vibrancy.py
+++ b/tests/test_vibrancy.py
@@ -1,15 +1,20 @@
+import sys
+import pytest
 import webview
+
+from .util import run_test
 
 
 def load_css(window):
     window.load_css('body { background: transparent !important; }')
 
 
-if __name__ == '__main__':
+@pytest.mark.skipif(sys.platform != 'darwin', reason='vibrancy is macOS only')
+def test_vibrancy():
     window = webview.create_window(
         'set vibrancy example',
         'https://pywebview.flowrl.com/hello',
         transparent=True,
         vibrancy=True,
     )
-    webview.start(load_css, window)
+    run_test(webview, window, start_args={'func': load_css, 'args': window})


### PR DESCRIPTION
The original test_multi_window.py tries to load the web page rendering with the GBM device. But, it shows the error and blocks test:
```
test_multi_window.py
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-6.2.5, py-1.10.0, pluggy-0.13.0 rootdir: /home/dev/pywebview/tests
collected 5 items

test_multi_window.py ..Unable to access the GBM device, disabling DMABuf video sink. [pywebview] Main window failed to start
Traceback (most recent call last):
  File "/home/dev/pywebview/tests/util.py", line 72, in thread
    thread_func(window)
  File "/home/dev/pywebview/tests/test_multi_window.py", line 110, in load_url
    child_window.destroy()
  File "/home/dev/pywebview/webview/window.py", line 45, in wrapper
    raise WebViewException('Main window failed to start')
webview.util.WebViewException: Main window failed to start
```
The graphic hardware acceleration and rendering API should be invoked by system's WebView/WebKit library, not pywebview. So, test with simple web pages.