### PR TITLE
add method to prevent secure coding WARNING on cocoa

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -73,6 +73,9 @@ class BrowserView:
                 i.closing.set()
             return Foundation.YES
 
+        def applicationSupportsSecureRestorableState_(self, app):
+            return Foundation.YES
+    
     class WindowHost(AppKit.NSWindow):
         def canBecomeKeyWindow(self):
             return self.focus


### PR DESCRIPTION
Later versions of MacOS give the warning:

```
WARNING: Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES.
```

This commit adds the method to address this warning.