### PR TITLE
[appveyor] Use Ubuntu 22.04 to test GTK platform

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image:
   - Ubuntu2004
-  - Ubuntu2004
+  - Ubuntu2204
   - macos
   - Visual Studio 2022
 for:
@@ -49,7 +49,7 @@ for:
   -
     matrix:
       only:
-        - image: Ubuntu2004
+        - image: Ubuntu2204
     environment:
       PYWEBVIEW_GUI: gtk
     install:


### PR DESCRIPTION
The original appveyor matrix uses two Ubuntu2004 images to test QT and GTK platforms. But, that might confuse the runner and always test QT platform. So, change GTK platform runner's image to Ubuntu2204.