### PR TITLE
[appveyor] Set display number to enable GTK test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,7 @@ for:
         - image: Ubuntu2204
     environment:
       PYWEBVIEW_GUI: gtk
+      DISPLAY: :99
     install:
       - sudo apt-get update -q
       - sudo apt-get install --no-install-recommends -y xvfb gir1.2-gtk-3.0 gir1.2-webkit2-4.0 python3-gi python3-gi-cairo python3-pep8 pyflakes3 python3-pytest python3-six


### PR DESCRIPTION
The Xvfb places the display server with number 99. So, set DISPLAY environment variable as ":99". Then, GTK tests can render on it.