### PR TITLE
[appveyor] Set display number to enable QT test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ for:
         - image: Ubuntu2004
     environment:
       PYWEBVIEW_GUI: qt
-      DISPLAY: "0.0"
+      DISPLAY: :99
       QT_QPA_PLATFORM: offscreen
     install:
       - sudo apt-get update -q


### PR DESCRIPTION
The QT version test always fails at "OpenGL context creation":
```
WebEngineContext used before QtWebEngine::initialize() or OpenGL context creation failed. Failed to create OpenGL context for format QSurfaceFormat(version 2.0, options QFlags<QSurfaceFormat::FormatOption>(), depthBufferSize 24, redBufferSize -1, greenBufferSize -1, blueBufferSize -1, alphaBufferSize -1, stencilBufferSize 8, samples 0, swapBehavior QSurfaceFormat::DefaultSwapBehavior, swapInterval 1, colorSpace QSurfaceFormat::DefaultColorSpace, profile  QSurfaceFormat::NoProfile) [3:3:0100/000000.882327:ERROR:zygote_linux.cc(614)] Zygote could not fork: process_type renderer numfds 3 child_pid -1 [3:3:0100/000000.882527:ERROR:zygote_linux.cc(646)] write: Broken pipe (32)
./run.sh: line 10:  8703 Aborted                 (core dumped) python3 -m pytest "$@"
test_evaluate_js.py
```
The Xvfb places the display server with number 99. So, set DISPLAY environment variable as ":99". Then, QT tests can render on it.