### PR TITLE
Support for nested API definitions

### DIFF
--- a/examples/js_api.py
+++ b/examples/js_api.py
@@ -73,7 +73,7 @@ html = """
     function doHeavyStuff() {
         var btn = document.getElementById('heavy-stuff-btn')
 
-        pywebview.api.doHeavyStuff().then(function(response) {
+        pywebview.api.heavy_stuff.doHeavyStuff().then(function(response) {
             showResponse(response)
             btn.onclick = doHeavyStuff
             btn.innerText = 'Perform a heavy operation'
@@ -85,7 +85,7 @@ html = """
     }
 
     function cancelHeavyStuff() {
-        pywebview.api.cancelHeavyStuff()
+        pywebview.api.heavy_stuff.cancelHeavyStuff()
     }
 
     function getRandomNumber() {
@@ -107,21 +107,9 @@ html = """
 """
 
 
-class Api:
+class HeavyStuffAPI:
     def __init__(self):
         self.cancel_heavy_stuff_flag = False
-
-    def init(self):
-        response = {'message': 'Hello from Python {0}'.format(sys.version)}
-        return response
-
-    def getRandomNumber(self):
-        response = {
-            'message': 'Here is a random number courtesy of randint: {0}'.format(
-                random.randint(0, 100000000)
-            )
-        }
-        return response
 
     def doHeavyStuff(self):
         time.sleep(0.1)  # sleep to prevent from the ui thread from freezing for a moment
@@ -145,6 +133,23 @@ class Api:
         time.sleep(0.1)
         self.cancel_heavy_stuff_flag = True
 
+
+
+class Api:
+    heavy_stuff = HeavyStuffAPI()
+
+    def init(self):
+        response = {'message': 'Hello from Python {0}'.format(sys.version)}
+        return response
+
+    def getRandomNumber(self):
+        response = {
+            'message': 'Here is a random number courtesy of randint: {0}'.format(
+                random.randint(0, 100000000)
+            )
+        }
+        return response
+
     def sayHelloTo(self, name):
         response = {'message': 'Hello {0}!'.format(name)}
         return response
@@ -156,4 +161,4 @@ class Api:
 if __name__ == '__main__':
     api = Api()
     window = webview.create_window('JS API example', html=html, js_api=api)
-    webview.start()
+    webview.start(debug=True)

--- a/tests/test_js_api.py
+++ b/tests/test_js_api.py
@@ -24,9 +24,20 @@ def test_concurrent():
     run_test(webview, window, concurrent)
 
 
+class NestedApi:
+    @classmethod
+    def get_int(cls):
+        return 422
+
+    def get_int_instance(self):
+        return 423
+
 class Api:
     class ApiTestException(Exception):
         pass
+
+    nested = NestedApi
+    nested_instance = NestedApi()
 
     def get_int(self):
         return 420
@@ -70,6 +81,8 @@ def js_bridge(window):
     assert_js(window, 'get_double_quote', 'te"st')
     assert_js(window, 'echo', 'test', 'test')
     assert_js(window, 'multiple', [1, 2, 3], 1, 2, 3)
+    assert_js(window, 'nested.get_int', 422)
+    assert_js(window, 'nested_instance.get_int_instance', 423)
 
 
 def exception(window):

--- a/webview/js/api.py
+++ b/webview/js/api.py
@@ -5,23 +5,28 @@ window.pywebview = {
     api: {},
 
     _createApi: function(funcList) {
-        funcList.forEach(({ func: funcName, params }) => {
+        funcList.forEach(function (element) {
+            var funcName = element.func;
+            var params = element.params;
+
             // Create nested structure and assign function
-            const funcHierarchy = funcName.split('.');
-            const functionName = funcHierarchy.pop();
-            const nestedObject = funcHierarchy.reduce((obj, prop) => {
-                return obj[prop] = obj[prop] || {};
+            var funcHierarchy = funcName.split('.');
+            var functionName = funcHierarchy.pop();
+            var nestedObject = funcHierarchy.reduce(function (obj, prop) {
+                if (!obj[prop]) {
+                    obj[prop] = {};
+                }
+                return obj[prop];
             }, window.pywebview.api);
 
             // Define the function body
-            const funcBody = `
-                var __id = (Math.random() + '').substring(2);
-                var promise = new Promise(function(resolve, reject) {
-                    window.pywebview._checkValue('${funcName}', resolve, reject, __id);
-                });
-                window.pywebview._bridge.call('${funcName}', arguments, __id);
-                return promise;
-            `;
+            var funcBody =
+                'var __id = (Math.random() + "").substring(2);' +
+                'var promise = new Promise(function(resolve, reject) {' +
+                '    window.pywebview._checkValue("' + funcName + '", resolve, reject, __id);' +
+                '});' +
+                'window.pywebview._bridge.call("' + funcName + '", arguments, __id);' +
+                'return promise;';
 
             // Assign the new function
             nestedObject[functionName] = new Function(params, funcBody);

--- a/webview/util.py
+++ b/webview/util.py
@@ -149,7 +149,7 @@ def parse_api_js(window: Window, platform: str, uid: str = '') -> str:
                 full_name = f"{base_name}.{name}" if base_name else name
                 functions[full_name] = get_args(attr)[1:]
             # If the attribute is a class or a non-callable object, make a recursive call
-            elif inspect.isclass(attr) or (isinstance(attr, object) and not callable(attr)):
+            elif inspect.isclass(attr) or (isinstance(attr, object) and not callable(attr) and hasattr(attr, "__module__")):
                 get_functions(attr, f"{base_name}.{name}" if base_name else name, functions)
 
         return functions


### PR DESCRIPTION
This PR introduces nested API definitions. Previously, only methods defined on the base API class instance were available on the frontend. The new structure allows for a more organized, readable, and scalable approach by grouping related functionalities into separate classes.

**Example Usage**:
```python
class MathAPI:
    @classmethod
    def add(cls, a: int, b: int):
        return a + b

    @classmethod
    def subtract(cls, a: int, b: int):
        return a - b

class GreetingAPI:
    @classmethod
    def greet(cls, name: str):
        return f"Hello, {name}!"

class RootAPI:
    math = MathAPI
    greetings = GreetingAPI

    @classmethod
    def ping(cls):
        return "pong"

if __name__ == '__main__':
    window = webview.create_window('JS API example', html=html, js_api=RootAPI)
    webview.start()
```

With this structure, the APIs can be accessed in JavaScript as follows:
- `pywebview.api.ping`
- `pywebview.api.math.add`
- `pywebview.api.math.subtract`
- `pywebview.api.greetings.greet`

**Benefits**:
- **Enhanced Organization**: Group related functionalities into classes.
- **Improved Readability**: Easier to navigate and understand the API structure.
- **Scalability**: More scalable for applications that require a large number of API endpoints.