### PR TITLE
fixed background color not available in webview2

### DIFF
--- a/webview/platforms/edgechromium.py
+++ b/webview/platforms/edgechromium.py
@@ -55,6 +55,7 @@ class EdgeChrome:
         self.web_view.NavigationCompleted += self.on_navigation_completed
         self.web_view.WebMessageReceived += self.on_script_notify
         self.syncContextTaskScheduler = TaskScheduler.FromCurrentSynchronizationContext()
+        self.web_view.DefaultBackgroundColor = Color.FromArgb(255, int(window.background_color.lstrip("#")[0:2], 16), int(window.background_color.lstrip("#")[2:4], 16), int(window.background_color.lstrip("#")[4:6], 16))
 
         if window.transparent:
             self.web_view.DefaultBackgroundColor = Color.Transparent


### PR DESCRIPTION
I noticed that setting the background_color property does not actually change anything on windows except for the "transparent" background setting. There still are a few problems for setting different alpha values, but normal rgb hex values are no problem, and this proves it. 

