### PR TITLE
Set `ScrolledWindow` policy to `NEVER`

### DIFF
--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -117,6 +117,7 @@ class BrowserView:
         )
 
         scrolled_window = gtk.ScrolledWindow()
+        scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.NEVER)
         self.window.add(scrolled_window)
 
         self.window.connect('delete-event', self.close_window)


### PR DESCRIPTION
Set the policy of the `Gtk.ScrolledWindow()` to `Gtk.PolicyType.NEVER`.

Fixes #1332