### PR TITLE
Fix for blank screen with QT in Pop!_OS (no-sandbox flag)

### DIFF
--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -46,7 +46,7 @@ except ImportError:
     is_webengine = False
     renderer = 'qtwebkit'
 
-if is_webengine and QtCore.QSysInfo.productType() in ['arch', 'manjaro', 'nixos','rhel']:
+if is_webengine and QtCore.QSysInfo.productType() in ['arch', 'manjaro', 'nixos', 'rhel', 'pop']:
     # I don't know why, but it's a common solution for #890 (White screen displayed)
     # such as:
     # - https://github.com/LCA-ActivityBrowser/activity-browser/pull/954/files


### PR DESCRIPTION
This simple example just showed a blank/white screen, even after installing the dependencies:

```py
import webview
webview.create_window('Hello world', html = '<h1>Hello world</h1>')
webview.start(debug = True)
```

The logs didn't help as it didn't show anything more than:

```console
$ PYWEBVIEW_LOG=debug PYWEBVIEW_GUI=qt python test.py
[pywebview] Using Qt 5.15.2

DevTools listening on ws://127.0.0.1:8228/devtools/browser/43d54d29-4157-44fa-ad66-2200c783fa29
<PyQt5.QtWebEngineWidgets.QWebEngineProfile object at 0x7d20c5fe3910>
Remote debugging server started successfully. Try pointing a Chromium-based browser to http://127.0.0.1:8228
```

Then I searched through the issues and came across to this https://github.com/r0x0r/pywebview/issues/1325#issuecomment-1981757261 and this PR #1189,

And apparently adding these flags now fixes the issue:

```console
$ PYWEBVIEW_LOG=debug PYWEBVIEW_GUI=qt QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --no-sandbox" python test.py
```

So this pull request adds Pop!_OS to no-sandbox list, the distro ID is `pop`:

```console
$ cat /etc/os-release | grep ^ID=
ID=pop
```

By the way, I believe this should be documented somewhere (or maybe add a new parameter to `webview.start` maybe?) so people on other Linux distributions can fix it on their own without hard-coding distro IDs.

---

Tested on:
- OS/kernel version: `Pop!_OS 22.04 LTS (Linux 6.8.0-76060800daily20240311-generic, x86-64)`
- Web renderer: `qt`
- Webview user agent: `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.15.2 Chrome/83.0.4103.122 Safari/537.36`
- Python version: `3.11.5` in a venv