### PR TITLE
fix 2 errors while "buildozer -v android debug deploy run"

### DIFF
--- a/examples/todos/buildozer.spec
+++ b/examples/todos/buildozer.spec
@@ -22,7 +22,7 @@ source.include_exts = py,png,jpg,kv,atlas,html,jar
 source.exclude_exts = spec,
 
 # (list) List of directory to exclude (let empty to not exclude anything)
-source.exclude_dirs = bin,build,dist,docs,logo,tests,pywebview.egg-info,
+source.exclude_dirs = bin,build,dist,docs,logo,tests,pywebview.egg-info
 
 # (list) List of exclusions using pattern matching
 # Do not prefix with './'

--- a/examples/todos/buildozer.spec
+++ b/examples/todos/buildozer.spec
@@ -4,7 +4,7 @@
 title = pywebview todos
 
 # (str) Package name
-package.name = pywebview todos
+package.name = pywebviewTodos
 
 # (str) Package domain (needed for android/ios packaging)
 package.domain = com.pywebview.todos


### PR DESCRIPTION
1.fixed the error "clang-14: error: no such file or directory: 'todos/arm64-v8a'", the buildozer package.name requirement is one word with only ASCII characters and/or numbers. It should not contain any special characters
2.fix the error "if exclude_dir[-1] != '/':IndexError: string index out of range" while "buildozer -v android release"