### PR TITLE
Add `py.typed` marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ packages = ["webview", "webview.dom", "webview.js", "webview.lib", "webview.plat
 
 [tool.setuptools.package-data]
 "webview.lib" = ["**/*.dll", "**/*.jar"]
+"webview" = ["py.typed"]
 
 [tool.setuptools_scm]
 write_to = "webview/_version.py"


### PR DESCRIPTION
`mypy` is complaining that `webview` doesn't have a `py.typed` marker file, even though the codebase seems to be type annotated already. This PR adds the marker.