### PR TITLE
Replace `ssl.wrap_socket` with `SSLContext(...).wrap_socket()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pythonnet;sys_platform=='win32'",
     "pyobjc-core;sys_platform=='darwin'",
     "pyobjc-framework-Cocoa;sys_platform=='darwin'",
+    "pyobjc-framework-Quartz;sys_platform=='darwin'",
     "pyobjc-framework-WebKit;sys_platform=='darwin'",
     "pyobjc-framework-security;sys_platform=='darwin'",
     "QtPy;sys_platform=='openbsd6'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pythonnet; sys_platform == "win32"
 pyobjc-core; sys_platform == "darwin"
 pyobjc-framework-Cocoa; sys_platform == "darwin"
+pyobjc-framework-Quartz; sys_platform == "darwin"
 pyobjc-framework-WebKit; sys_platform == "darwin"
 pyobjc-framework-Security; sys_platform == "darwin"
 PyQt5; sys_platform == "openbsd6" or sys_platform == "linux"

--- a/webview/http.py
+++ b/webview/http.py
@@ -183,13 +183,10 @@ class SSLWSGIRefServer(bottle.ServerAdapter):
                 class server_cls(server_cls):
                     address_family = socket.AF_INET6
 
+        ssl_context = ssl.SSLContext()
+        ssl_context.load_cert_chain(self.pywebview_certfile, self.pywebview_keyfile)
         self.srv = make_server(self.host, self.port, handler, server_cls, handler_cls)
-        self.srv.socket = ssl.wrap_socket(
-            self.srv.socket,
-            keyfile=self.pywebview_keyfile,
-            certfile=self.pywebview_certfile,
-            server_side=True,
-        )
+        self.srv.socket = ssl_context.wrap_socket(self.srv.socket, server_side=True)
         self.port = self.srv.server_port  # update port actual port (0 means random)
         os.unlink(self.pywebview_keyfile)
         try:

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -637,7 +637,8 @@ class BrowserView:
             self.minimize()
 
         if not BrowserView.app.isRunning():
-            # Add the default Cocoa application menu
+            # Reset the application menu to the defaults
+            self._clear_main_menu()
             self._add_app_menu()
             self._add_view_menu()
 
@@ -879,6 +880,14 @@ class BrowserView:
             self._file_name_semaphore.acquire()
 
         return self._file_name
+
+    def _clear_main_menu(self):
+        """
+        Remove all items from the main menu.
+        """
+        mainMenu = BrowserView.app.mainMenu()
+        if mainMenu:
+            mainMenu.removeAllItems()
 
     def _add_app_menu(self):
         """


### PR DESCRIPTION
`SSLContext().wrap_socket()` has been recommended over `ssl.wrap_socket()` since python 3.2.
`ssl.wrap_socket()` has been deprecated since python 3.7 and has been removed in 3.12.

Also add a missing Darwin dependency (`pyobjc-framework-Quartz`) and fix a bug where the Cocoa app main menu keeps acquiring duplicate default items on every call to `BrowserView.first_show()`.