### PR TITLE
only create the data task when user press ok

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -268,13 +268,12 @@ class BrowserView:
 
                 if save_dlg.runModal() == AppKit.NSFileHandlingPanelOKButton:
                     self._file_name = save_dlg.filename()
+                    dataTask = Foundation.NSURLSession.sharedSession().downloadTaskWithURL_completionHandler_(
+                        navigationResponse.response().URL(), self.download_completionHandler_error_
+                    )
+                    dataTask.resume()
                 else:
                     self._file_name = None
-
-                dataTask = Foundation.NSURLSession.sharedSession().downloadTaskWithURL_completionHandler_(
-                    navigationResponse.response().URL(), self.download_completionHandler_error_
-                )
-                dataTask.resume()
             else:
                 decisionHandler(WebKit.WKNavigationResponsePolicyCancel)
 


### PR DESCRIPTION
Hi there, I found a nil pointer dereference during file download on coca platform.

When I cancel the file download dialog, pywebview will crash because of creating the data task with None `self._file_name` in the `download_completionHandler_error_`.

https://github.com/r0x0r/pywebview/blob/master/webview/platforms/cocoa.py#L286

And here is the piece of crash log:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSURL initFileURLWithPath:]: nil string parameter'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000018b3572ec __exceptionPreprocess + 176
	1   libobjc.A.dylib                     0x000000018ae3e788 objc_exception_throw + 60
	2   _objc.cpython-311-darwin.so         0x000000010a20e158 python_exception_to_objc + 0
	3   _objc.cpython-311-darwin.so         0x000000010a1d81a4 method_stub + 11552
	4   libffi.dylib                        0x000000019c1d1f30 ffi_closure_SYSV_inner + 820
	5   libffi.dylib                        0x000000019c1c91e8 ffi_closure_SYSV + 56
	6   CFNetwork                           0x00000001905dbb54 CFURLCredentialStorageCopyAllCredentials + 21480
	7   CFNetwork                           0x00000001905f65cc _CFHTTPMessageSetResponseProxyURL + 15820
	8   libdispatch.dylib                   0x000000018b050750 _dispatch_call_block_and_release + 32
	9   libdispatch.dylib                   0x000000018b0523e8 _dispatch_client_callout + 20
	10  libdispatch.dylib                   0x000000018b059a14 _dispatch_lane_serial_drain + 748
	11  libdispatch.dylib                   0x000000018b05a578 _dispatch_lane_invoke + 432
	12  libdispatch.dylib                   0x000000018b0652d0 _dispatch_root_queue_drain_deferred_wlh + 288
	13  libdispatch.dylib                   0x000000018b064b44 _dispatch_workloop_worker_thread + 404
	14  libsystem_pthread.dylib             0x000000018b1ff00c _pthread_wqthread + 288
	15  libsystem_pthread.dylib             0x000000018b1fdd28 start_wqthread + 8
)
libc++abi: terminating due to uncaught exception of type NSException
```

I'm not familiar with the macOS Cocoa but this fix the crashing. Any feedback or suggestions to enhance this fix would be appreciated.
