### PR TITLE
Update winforms.py

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -693,7 +693,12 @@ def set_title(title, uid):
         _set_title()
 
 
-def create_confirmation_dialog(title, message, _):
+def create_confirmation_dialog(title, message, uid):
+    i = BrowserView.instances.get(uid)
+
+    if not i:
+        return
+        
     result = WinForms.MessageBox.Show(message, title, WinForms.MessageBoxButtons.OKCancel)
     return result == WinForms.DialogResult.OK
 


### PR DESCRIPTION
修复问题：当窗口置顶时弹出确认框位于窗口底部，且使用pyinstaller打包后会无响应

Fixed the problem: when the window is fixed to the top, the pop-up confirmation box is located at the bottom of the window, and it will be unresponsive after packaging with pyinstaller