### PR TITLE
[winforms] fix: windows 7 compatibility

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -172,7 +172,9 @@ class BrowserView:
             self.AutoScaleDimensions = SizeF(96.0, 96.0)
             self.AutoScaleMode = WinForms.AutoScaleMode.Dpi
             # for chromium edge, need this factor to modify the coordinates
-            self.scale_factor = windll.shcore.GetScaleFactorForDevice(0) / 100 if is_chromium else 1
+            try:
+                self.scale_factor = windll.shcore.GetScaleFactorForDevice(0) / 100 if is_chromium else 1
+            except: self.scale_factor = 1
 
             if window.initial_x is not None and window.initial_y is not None:
                 self.StartPosition = WinForms.FormStartPosition.Manual

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -171,10 +171,12 @@ class BrowserView:
 
             self.AutoScaleDimensions = SizeF(96.0, 96.0)
             self.AutoScaleMode = WinForms.AutoScaleMode.Dpi
+            
             # for chromium edge, need this factor to modify the coordinates
             try:
                 self.scale_factor = windll.shcore.GetScaleFactorForDevice(0) / 100 if is_chromium else 1
-            except: self.scale_factor = 1
+            except:
+                self.scale_factor = 1
 
             if window.initial_x is not None and window.initial_y is not None:
                 self.StartPosition = WinForms.FormStartPosition.Manual


### PR DESCRIPTION
the shcore dll is not present on Windows 7, this adds an exception handler for this case