### PR TITLE
fix: Set WebView2 user data path

### DIFF
--- a/webview/platforms/edgechromium.py
+++ b/webview/platforms/edgechromium.py
@@ -77,7 +77,9 @@ class EdgeChrome:
         def _callback(task):
             self.web_view.EnsureCoreWebView2Async(task.Result)
 
-        environment = CoreWebView2Environment.CreateAsync()
+        environment = CoreWebView2Environment.CreateAsync(
+            userDataFolder=_settings['storage_path']
+        )
         environment.ContinueWith(
             Action[Task[CoreWebView2Environment]](_callback),
             self.syncContextTaskScheduler,


### PR DESCRIPTION
### Problem:

After building a project using PyInstaller into a single executable file, during the application's runtime, a folder named "exe.WebView2" was created next to the executable file. Due to the location of the executable, the application lacked the necessary permissions to modify its folder, leading to runtime issues.

Attempts to resolve this issue by following the suggestions mentioned in [this discussion](https://github.com/r0x0r/pywebview/issues/1037#issuecomment-1424732083) did not yield the desired results.

### Solution:

Upon consulting the WebView2 documentation, specifically the "Manage user data folders" section [(source)](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/user-data-folder?tabs=dotnet), I discovered that it's possible to specify a custom path for the creation of the user data folder.

I modified the setup_webview2_environment method in the edgechromium.py file to include the `userDataFolder` parameter when calling `CoreWebView2Environment.CreateAsync`. By setting the path to `_settings['storage_path']`, I was able to direct the WebView2 data folder to a location with the appropriate permissions, fully addressing the issue.

This change ensures that the WebView2 data folder is created in a specified.