### PR TITLE
Replaced internal URL with permalink

### DIFF
--- a/docs/guide/freezing.md
+++ b/docs/guide/freezing.md
@@ -16,7 +16,7 @@ from webview import util
 print(util.android_jar_path())
 ```
 
-You can see a sample `bulldozer.spec` [here](https://github.com/r0x0r/pywebview/blob/master/examples/todos/bulldozer.spec)
+You can see a sample `bulldozer.spec` [here](https://github.com/r0x0r/pywebview/blob/a2b8d0449b206db75f9f364639b85db6eac7f07e/examples/todos/buildozer.spec)
 
 ## macOS
 


### PR DESCRIPTION
For some reasons - maybe Github's internal CDN design, the file "pretty" URL isn't enough to access the resource in GitHub when used from external sources. Permalink surely does.  The original link was working from within GitHub but not when it was clicked from PyWebView documentation.