### PR TITLE
Handle UNIX paths in drag-and-drop events on GTK

### DIFF
--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -244,13 +244,18 @@ class BrowserView:
         return False
 
     def on_drag_data(self, widget, drag_context, x, y, data, info, time):
-        if _dnd_state['num_listeners'] > 0 and data.get_text():
-            files = [
-                (os.path.basename(value), value.replace('file://', ''))
-                for value
-                in data.get_text().split('\n')
-                if value.startswith('file://')
-            ]
+        text = data.get_text()
+        if text and _dnd_state['num_listeners']:
+            if text.startswith('/'):
+                # Direct path case (e.g., `/home/user/file.txt`)
+                files = [(os.path.basename(text), text)]
+            else:
+                # 'file://' case (e.g., `file:///home/user/file.txt`)
+                files = [
+                    (os.path.basename(value), value.replace('file://', ''))
+                    for value in text.split('\n') if value.startswith('file://')
+                ]
+
             _dnd_state['paths'] += files
 
         return False


### PR DESCRIPTION
The GTK implementation of drag-and-drop events under Linux (tested on Fedora 40, GNOME Shell 46.5) sends a regular UNIX file path (e.g., /home/user/file.txt). However, the current pywebview implementation expects a file:// URI and discards anything else. This leads to pywebviewFullPath being empty despite valid file paths being provided in the drop event.

This commit updates the logic to handle both file:// URIs and standard UNIX paths, ensuring proper drag-and-drop functionality on GTK-based platforms.



https://github.com/user-attachments/assets/1a563870-daa1-46b4-8153-4a698313694d

