### PR TITLE
Allow configuring Chromium remote debugging port

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -99,7 +99,8 @@ webview.settings = {
   'ALLOW_DOWNLOADS': False,
   'ALLOW_FILE_URLS': True,
   'OPEN_EXTERNAL_LINKS_IN_BROWSER': True,
-  'OPEN_DEVTOOLS_IN_DEBUG': True
+  'OPEN_DEVTOOLS_IN_DEBUG': True,
+  'REMOTE_DEBUGGING_PORT': None
 }
 ```
 
@@ -109,6 +110,7 @@ Additional options that override default behaviour of _pywebview_ to address pop
 * `ALLOW_FILE_URLS` Enable `file://` urls. Disabled by default.
 * `OPEN_EXTERNAL_LINKS_IN_BROWSER`. Open `target=_blank` link in an external browser. Enabled by default.
 * `OPEN_DEVTOOLS_IN_DEBUG` Open devtools automatically in debug mode. Enabled by default.
+* `REMOTE_DEBUGGING_PORT` Enable remote debugging when using `edgechromium`. Disabled by default.
 
 #### Examples
 

--- a/examples/remote_debugging.py
+++ b/examples/remote_debugging.py
@@ -1,0 +1,13 @@
+import webview
+
+"""
+Enable remote debugging when using `edgechromium`.
+This can be used to write tests for the application using Playwright.
+See [https://playwright.dev/docs/webview2](https://playwright.dev/docs/webview2) for how to configure it.
+"""
+
+if __name__ == '__main__':
+    webview.settings['REMOTE_DEBUGGING_PORT'] = 9222
+
+    window = webview.create_window('Webview', 'https://pywebview.flowrl.com/hello')
+    webview.start()

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -76,6 +76,7 @@ settings = {
     'ALLOW_FILE_URLS': True,
     'OPEN_EXTERNAL_LINKS_IN_BROWSER': True,
     'OPEN_DEVTOOLS_IN_DEBUG': True,
+    'REMOTE_DEBUGGING_PORT': None,
 }
 
 guilib = None

--- a/webview/platforms/edgechromium.py
+++ b/webview/platforms/edgechromium.py
@@ -47,6 +47,9 @@ class EdgeChrome:
         if webview_settings['ALLOW_FILE_URLS']:
             props.AdditionalBrowserArguments += ' --allow-file-access-from-files'
 
+        if webview_settings['REMOTE_DEBUGGING_PORT'] is not None:
+            props.AdditionalBrowserArguments += f' --remote-debugging-port={webview_settings["REMOTE_DEBUGGING_PORT"]}'
+
         self.webview.CreationProperties = props
 
         self.form = form


### PR DESCRIPTION
Allow configuring the Chromium remote debugging port via `webview.settings`. This makes it possible write tests for the application using Playwright via this guide: https://playwright.dev/docs/webview2