### PR TITLE
Fix window change title example exit

### DIFF
--- a/examples/window_title_change.py
+++ b/examples/window_title_change.py
@@ -1,14 +1,15 @@
 """Change window title every three seconds."""
 
-import time
-
 import webview
 
 
 def change_title(window):
     """changes title every 3 seconds"""
     for i in range(1, 100):
-        time.sleep(3)
+        # exit loop when window is closed
+        if window.events.closed.wait(3):
+            break
+
         window.title = f'New Title #{i}'
         print(window.title)
 


### PR DESCRIPTION
Since the thread running the timer loop in `examples/window_title_change.py` is not a daemon thread, the program will not exit when the main thread ends due to the window closing.

Instead of using an uninterruptible sleep, we can use the window closed event as the timer with the added bonus that we can exit the timer loop when the window is closed so that the program can exit.