### PR TITLE
Fix `abortModal` call

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -106,7 +106,7 @@ class BrowserView:
             i.closed.set()
             if BrowserView.instances == {}:
                 BrowserView.app.stop_(self)
-                BrowserView.app.abortModal_()
+                BrowserView.app.abortModal()
 
         def windowDidResize_(self, notification):
             i = BrowserView.get_instance('window', notification.object())


### PR DESCRIPTION
44033b8589e462017f097b6274094fee4945647c added a call to [`abortModal()`](https://developer.apple.com/documentation/appkit/nsapplication/1428753-abortmodal), but with an extra `_` that means the call fails and prints `<class 'AttributeError'>: 'NSApplication' object has no attribute 'abortModal_'` on every exit. This commit removes the underscore.