### PR TITLE
Correct `Menu` typing

### DIFF
--- a/webview/menu.py
+++ b/webview/menu.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any, Union
 
 
 class Menu:
-    def __init__(self, title: str, items: list[str] = []) -> None:
+    def __init__(self, title: str, items: list[Union[Menu, MenuAction, MenuSeparator]] = []) -> None:
         """
         Args:
             title: the menu or submenu title
@@ -15,7 +16,7 @@ class Menu:
 
 
 class MenuAction:
-    def __init__(self, title: str, function: Callable[[], None]) -> None:
+    def __init__(self, title: str, function: Callable[[], Any]) -> None:
         self.title = title
         self.function = function
         # TODO: support platform-agnostic shortcut


### PR DESCRIPTION
This pull request includes changes to the `webview/menu.py` file to fix type annotations.

Changes:

* [`webview/menu.py`](diffhunk://#diff-9d70e0c5c34ec7abc473ffce69d2af75c077c04318ae94332537380b2fd553f2L7-R8): Updated the `Menu` class initializer to accept a list of items that can be `Menu`, `MenuAction`, or `MenuSeparator` instead of `str`.
* [`webview/menu.py`](diffhunk://#diff-9d70e0c5c34ec7abc473ffce69d2af75c077c04318ae94332537380b2fd553f2L18-R19): Modified the `MenuAction` class initializer to allow the `function` argument to return any type instead of `None`.