### PR TITLE
Implemented Adding Cookies Functionality

### DIFF
--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -14,6 +14,9 @@ def window():
 def test_get_cookies(window):
     run_test(webview, window, get_cookies_test)
 
+def test_add_cookie(window):
+    run_test(webview, window, add_cookie_test)
+
 
 @pytest.mark.skipif(os.environ.get('PYWEBVIEW_GUI') == 'qt', reason='This test crashes QT')
 def test_clear_cookies(window):
@@ -24,6 +27,12 @@ def get_cookies_test(window):
     cookies = window.get_cookies()
     assert len(cookies) == 1
     assert cookies[0].output().startswith('Set-Cookie: pywebview=true; Domain=127.0.0.1;')
+
+def add_cookie_test(window):
+    window.clear_cookies()
+    cookies = window.add_cookie('TEST_KEY', 'TEST_VALUE', '127.0.0.1', '/')
+    cookies = window.get_cookies()
+    assert len(cookies) == 1
 
 
 def clear_cookies_test(window):

--- a/webview/platforms/android.py
+++ b/webview/platforms/android.py
@@ -11,7 +11,7 @@ from kivy.clock import Clock
 from jnius import autoclass, cast, java_method, PythonJavaClass
 from android.runnable import Runnable, run_on_ui_thread
 
-from webview import _state, settings
+from webview import _settings, settings
 from webview.util import create_cookie, js_bridge_call, inject_pywebview
 
 AlertDialogBuilder = autoclass('android.app.AlertDialog$Builder')
@@ -114,14 +114,19 @@ class BrowserView(Widget):
         def js_api_handler(func, params, id):
             js_bridge_call(self.window, func, json.loads(params), id)
 
+        def loaded_callback(event, data):
+            self.window.events.loaded.set()
+
         def chrome_callback(event, data):
             print(event, data)
 
         def webview_callback(event, data):
             if event == 'onPageFinished':
-                inject_pywebview(renderer, self.window)
+                value_callback = JavascriptValueCallback()
+                value_callback.setCallback(EventCallbackWrapper(loaded_callback))
+                self.webview.evaluateJavascript(inject_pywebview(self.window, renderer), value_callback)
 
-                if not _state['private_mode']:
+                if not _settings['private_mode']:
                     CookieManager.getInstance().setAcceptCookie(True)
                     CookieManager.getInstance().acceptCookie()
                     CookieManager.getInstance().flush()
@@ -146,14 +151,14 @@ class BrowserView(Widget):
         webview_settings.setLoadWithOverviewMode(True)
         webview_settings.setSupportZoom(self.window.zoomable)
         webview_settings.setBuiltInZoomControls(False)
-        webview_settings.setDomStorageEnabled(not _state['private_mode'])
+        webview_settings.setDomStorageEnabled(not _settings['private_mode'])
 
-        if _state['user_agent']:
-            webview_settings.setUserAgentString(_state['user_agent'])
+        if _settings['user_agent']:
+            webview_settings.setUserAgentString(_settings['user_agent'])
 
         self._webview_callback_wrapper = EventCallbackWrapper(webview_callback)
         webview_client = PyWebViewClient()
-        webview_client.setCallback(self._webview_callback_wrapper, _state['ssl'] or settings['IGNORE_SSL_ERRORS'])
+        webview_client.setCallback(self._webview_callback_wrapper, _settings['ssl'])
         self.webview.setWebViewClient(webview_client)
 
         self._chrome_callback_wrapper = EventCallbackWrapper(chrome_callback)
@@ -182,7 +187,7 @@ class BrowserView(Widget):
         self.window.events.shown.set()
 
     def dismiss(self):
-        if _state['private_mode']:
+        if _settings['private_mode']:
             self.webview.clearHistory()
             self.webview.clearCache(True)
             self.webview.clearFormData()
@@ -294,20 +299,23 @@ def setup_app():
 
 @run_on_ui_thread
 def load_url(url, _):
+    app.window.events.loaded.clear()
     app.view._cookies = {}
     app.view.webview.loadUrl(url)
 
 
 @run_on_ui_thread
 def load_html(html_content, base_uri, _):
+    app.window.events.loaded.clear()
     app.view._cookies = {}
     app.view.webview.loadDataWithBaseURL(base_uri, html_content, 'text/html', 'UTF-8', None)
 
 
-def evaluate_js(js_code, _, parse_json=True):
+def evaluate_js(js_code, unique_id):
     def callback(event, result):
         nonlocal js_result
-        js_result = json.loads(result) if parse_json and result else result
+        result = json.loads(result)
+        js_result = json.loads(result) if result else None
         lock.release()
 
     def _evaluate_js():

--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -6,7 +6,7 @@ from threading import Semaphore, Thread, main_thread
 from typing import Any
 from uuid import uuid1
 
-from webview import (FOLDER_DIALOG, OPEN_DIALOG, SAVE_DIALOG, _state, settings,
+from webview import (FOLDER_DIALOG, OPEN_DIALOG, SAVE_DIALOG, _settings, settings,
                      parse_file_type, windows)
 from webview.dom import _dnd_state
 from webview.menu import Menu, MenuAction, MenuSeparator
@@ -127,7 +127,7 @@ class BrowserView:
 
         self.js_bridge = BrowserView.JSBridge(window)
 
-        storage_path = _state['storage_path'] or os.path.join(os.path.expanduser('~'), '.pywebview')
+        storage_path = _settings['storage_path'] or os.path.join(os.path.expanduser('~'), '.pywebview')
 
         if not os.path.exists(storage_path):
             os.makedirs(storage_path)
@@ -135,7 +135,7 @@ class BrowserView:
         web_context = webkit.WebContext.get_default()
         self.cookie_manager = web_context.get_cookie_manager()
 
-        if not _state['private_mode']:
+        if not _settings['private_mode']:
             self.cookie_manager.set_persistent_storage(
                 os.path.join(storage_path, 'cookies'), webkit.CookiePersistentStorage.SQLITE
             )
@@ -150,14 +150,11 @@ class BrowserView:
         self.webview.connect('decide-policy', self.on_navigation)
         self.webview.connect('drag-data-received', self.on_drag_data)
 
-        if settings['IGNORE_SSL_ERRORS']:
-            web_context.set_tls_errors_policy(webkit.TLSErrorsPolicy.IGNORE)
-
         if settings['ALLOW_DOWNLOADS']:
             web_context.connect('download-started', self.on_download_started)
 
         webkit_settings = self.webview.get_settings().props
-        user_agent = settings.get('user_agent') or _state['user_agent']
+        user_agent = settings.get('user_agent') or _settings['user_agent']
         if user_agent:
             webkit_settings.user_agent = user_agent
 
@@ -187,7 +184,7 @@ class BrowserView:
             wvbg.alpha = 0.0
             self.webview.set_background_color(wvbg)
 
-        if _state['debug']:
+        if _settings['debug']:
             webkit_settings.enable_developer_extras = True
 
             if settings['OPEN_DEVTOOLS_IN_DEBUG']:
@@ -195,16 +192,16 @@ class BrowserView:
         else:
             self.webview.connect('context-menu', lambda a, b, c, d: True)  # Disable context menu
 
-        if _state['private_mode']:
+        if _settings['private_mode']:
             webkit_settings.enable_html5_database = False
             webkit_settings.enable_html5_local_storage = False
 
         self.webview.set_opacity(0.0)
         scrolled_window.add(self.webview)
 
-        if _state['icon']:
-            self.window.set_icon_from_file(_state['icon'])
-            self.window.set_default_icon_from_file(_state['icon'])
+        if _settings['icon']:
+            self.window.set_icon_from_file(_settings['icon'])
+            self.window.set_default_icon_from_file(_settings['icon'])
 
         self.pywebview_window.events.before_show.set()
 
@@ -316,7 +313,7 @@ class BrowserView:
             glib.idle_add(webview.set_opacity, 1.0)
 
         if status == webkit.LoadEvent.FINISHED:
-            inject_pywebview(renderer, self.js_bridge.window)
+            self._set_js_api()
 
     def on_download_started(self, session, download):
         download.connect('decide-destination', self.on_download_decide_destination)
@@ -521,6 +518,8 @@ class BrowserView:
 
             semaphore.release()
 
+        self.loaded.wait()
+
         cookies = []
         semaphore = Semaphore(0)
         glib.idle_add(_get_cookies)
@@ -529,54 +528,55 @@ class BrowserView:
         return cookies
 
     def get_current_url(self):
+        self.loaded.wait()
         uri = self.webview.get_uri()
         return uri if uri != 'about:blank' else None
 
     def load_url(self, url):
+        self.loaded.clear()
         self.webview.load_uri(url)
 
     def load_html(self, content, base_uri):
+        self.loaded.clear()
         self.webview.load_html(content, base_uri)
 
-    def evaluate_js(self, script, parse_json):
+    def evaluate_js(self, script):
         def _evaluate_js():
-            try:
-                self.webview.evaluate_javascript(
-                        script=script,
-                        length=len(script),
-                        world_name=None,
-                        source_uri=None,
-                        cancellable=None,
-                        callback=_callback)
-            except Exception:
-                logger.exception(e)
-                result_semaphore.release()
-
+            self.webview.evaluate_javascript(
+                    script=script,
+                    length=len(script),
+                    world_name=None,
+                    source_uri=None,
+                    cancellable=None,
+                    callback=_callback)
 
         def _callback(webview, task):
-            nonlocal result
-            try:
-                s = script
-                value = webview.evaluate_javascript_finish(task)
-                res = self._convert_js_value(value)
+            value = webview.evaluate_javascript_finish(task)
+            result = value.to_string() if value else None
 
-                if parse_json and res:
-                    try:
-                        result = json.loads(res)
-                    except Exception:
-                        pass
-                else:
-                    result = res
-
-            except Exception as e:
-                logger.exception(e)
+            if unique_id in self.js_results:
+                self.js_results[unique_id]['result'] = result
 
             result_semaphore.release()
 
+        unique_id = uuid1().hex
         result_semaphore = Semaphore(0)
-        result = None
+        self.js_results[unique_id] = {'semaphore': result_semaphore, 'result': None}
+
+        self.loaded.wait()
         glib.idle_add(_evaluate_js)
         result_semaphore.acquire()
+
+        result = self.js_results[unique_id]['result']
+        result = (
+            None
+            if result == 'undefined' or result == 'null' or result is None
+            else result
+            if result == ''
+            else json.loads(result)
+        )
+
+        del self.js_results[unique_id]
 
         return result
 
@@ -591,25 +591,20 @@ class BrowserView:
         dialog.run()
         dialog.destroy()
 
-    def _convert_js_value(self, js_value):
-        if not js_value or js_value.is_null() or js_value.is_undefined():
-            return None
-        elif js_value.is_boolean():
-            return js_value.to_boolean()
-        elif js_value.is_number():
-            return js_value.to_double()
-        elif js_value.is_string():
-            return js_value.to_string()
-        elif js_value.is_object():
-            js_object = js_value.to_object()
-            python_dict = {}
-            properties = js_object.get_property_names()
-            for prop in properties:
-                python_dict[prop] = self._js_value_to_python(js_object.get_property(prop))
-            return python_dict
-        else:
-            logger.error(f'Unsupported JavaScriptCore.Value type: {js_value}')
-            return js_value.to_string()
+    def _set_js_api(self):
+        def create_bridge():
+            script = inject_pywebview(self.js_bridge.window, renderer)
+            self.webview.evaluate_javascript(
+                    script=script,
+                    length=len(script),
+                    world_name=None,
+                    source_uri=None,
+                    cancellable=None,
+                    callback=None)
+
+            self.loaded.set()
+
+        glib.idle_add(create_bridge)
 
 
 def setup_app():
@@ -894,11 +889,11 @@ def create_file_dialog(dialog_type, directory, allow_multiple, save_filename, fi
     return file_names[0]
 
 
-def evaluate_js(script, uid, parse_json=True):
+def evaluate_js(script, uid):
     i = BrowserView.instances.get(uid)
 
     if i:
-        return i.evaluate_js(script, parse_json)
+        return i.evaluate_js(script)
 
 
 def get_position(uid):

--- a/webview/platforms/mshtml.py
+++ b/webview/platforms/mshtml.py
@@ -2,12 +2,14 @@ import json
 import logging
 import sys
 import webbrowser
+import winreg
 from ctypes import windll
 from threading import Semaphore
+from time import sleep
 
 import clr
 
-from webview import _state
+from webview import _settings
 from webview.util import (DEFAULT_HTML, inject_base_uri, interop_dll_path, js_bridge_call,
                           inject_pywebview)
 
@@ -15,7 +17,6 @@ clr.AddReference('System.Windows.Forms')
 clr.AddReference('System.Collections')
 clr.AddReference('System.Threading')
 
-from System import Func, Type
 import System.Windows.Forms as WinForms
 
 clr.AddReference(interop_dll_path('WebBrowserInterop.dll'))
@@ -122,18 +123,18 @@ class MSHTML:
         self.pywebview_window = window
         self.webview = WebBrowserEx()
         self.webview.Dock = WinForms.DockStyle.Fill
-        self.webview.ScriptErrorsSuppressed = not _state['debug']
-        self.webview.IsWebBrowserContextMenuEnabled = _state['debug']
+        self.webview.ScriptErrorsSuppressed = not _settings['debug']
+        self.webview.IsWebBrowserContextMenuEnabled = _settings['debug']
         self.webview.WebBrowserShortcutsEnabled = False
         self.webview.DpiAware = True
         MSHTML.alert = alert
 
-        user_agent = _state['user_agent'] or settings.get('user_agent')
+        user_agent = _settings['user_agent'] or settings.get('user_agent')
         if user_agent:
             self.webview.ChangeUserAgent(user_agent)
 
-        self.webview.ScriptErrorsSuppressed = not _state['debug']
-        self.webview.IsWebBrowserContextMenuEnabled = _state['debug']
+        self.webview.ScriptErrorsSuppressed = not _settings['debug']
+        self.webview.IsWebBrowserContextMenuEnabled = _settings['debug']
 
         self.js_result_semaphore = Semaphore(0)
         self.js_bridge = MSHTML.JSBridge()
@@ -167,28 +168,14 @@ class MSHTML:
         self.form = form
         form.Controls.Add(self.webview)
 
-    def evaluate_js(self, script, parse_json=True):
-        def _evaluate_js():
-            nonlocal result
-            res = self.webview.Document.InvokeScript('eval', (script,))
-
-            if parse_json and res is not None:
-                try:
-                    result = json.loads(res)
-                except Exception:
-                    result = res
-            else:
-                result = res
-            lock.release()
-
-        result = None
-        lock = Semaphore(0)
-        self.form.Invoke(Func[Type](_evaluate_js))
-        lock.acquire()
-        return result
+    def evaluate_js(self, script):
+        result = self.webview.Document.InvokeScript('eval', (script,))
+        self.js_result = None if result is None or result == 'null' else json.loads(result)  ##
+        self.js_result_semaphore.release()
 
     def load_html(self, content, base_uri):
         self.webview.DocumentText = inject_base_uri(content, base_uri)
+        self.pywebview_window.events.loaded.clear()
 
     def load_url(self, url):
         self.webview.Navigate(url)
@@ -224,7 +211,7 @@ class MSHTML:
     def on_document_completed(self, _, args):
         document = self.webview.Document
 
-        if _state['debug']:
+        if _settings['debug']:
             document.InvokeScript(
                 'eval', """
                     window.console = {
@@ -239,7 +226,10 @@ class MSHTML:
             self.first_load = False
 
         self.url = None if args.Url.AbsoluteUri == 'about:blank' else str(args.Url.AbsoluteUri)
-        inject_pywebview(renderer, self.pywebview_window)
+
+        document.InvokeScript('eval', (inject_pywebview(self.pywebview_window, renderer),))
+        sleep(0.1)
+        self.pywebview_window.events.loaded.set()
 
         if self.pywebview_window.easy_drag:
             document.MouseMove += self.on_mouse_move

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -11,7 +11,7 @@ from functools import partial
 from threading import Event, Semaphore, Thread
 from uuid import uuid1
 
-from webview import (FOLDER_DIALOG, OPEN_DIALOG, SAVE_DIALOG, _state, windows, settings)
+from webview import (FOLDER_DIALOG, OPEN_DIALOG, SAVE_DIALOG, _settings, windows, settings)
 from webview.dom import _dnd_state
 from webview.menu import Menu, MenuAction, MenuSeparator
 from webview.screen import Screen
@@ -63,7 +63,7 @@ _main_window_created.clear()
 # suppress invalid style override error message on some Linux distros
 os.environ['QT_STYLE_OVERRIDE'] = ''
 _qt6 = True if PYQT6 or PYSIDE6 else False
-_profile_storage_path = _state['storage_path'] or os.path.join(os.path.expanduser('~'), '.pywebview')
+_profile_storage_path = _settings['storage_path'] or os.path.join(os.path.expanduser('~'), '.pywebview')
 
 
 class BrowserView(QMainWindow):
@@ -214,9 +214,9 @@ class BrowserView(QMainWindow):
 
     # New-window-requests handler for Qt 5.5+ only
     class NavigationHandler(QWebPage):
-        def __init__(self, page):
-            super().__init__(page.profile())
-            self.parent = page.parent
+        def __init__(self, page, parent):
+            self.parent = parent
+            super(BrowserView.NavigationHandler, self).__init__(page)
 
         def acceptNavigationRequest(self, url, type, is_main_frame):
             if settings['OPEN_EXTERNAL_LINKS_IN_BROWSER']:
@@ -228,7 +228,6 @@ class BrowserView(QMainWindow):
 
     class WebPage(QWebPage):
         def __init__(self, parent=None, profile=None):
-            self.parent = parent
             if is_webengine and profile:
                 super(BrowserView.WebPage, self).__init__(profile, parent.webview)
             else:
@@ -236,7 +235,7 @@ class BrowserView(QMainWindow):
 
             if is_webengine:
                 self.featurePermissionRequested.connect(self.onFeaturePermissionRequested)
-                self.nav_handler = BrowserView.NavigationHandler(self)
+                self.nav_handler = BrowserView.NavigationHandler(self, parent)
             else:
                 self.nav_handler = None
 
@@ -264,7 +263,7 @@ class BrowserView(QMainWindow):
                 return True
 
         def userAgentForUrl(self, url):
-            user_agent = _state['user_agent']
+            user_agent = _settings['user_agent']
             if user_agent:
                 return user_agent
             else:
@@ -356,7 +355,7 @@ class BrowserView(QMainWindow):
                 '--enable-features=AutoplayIgnoreWebAudio',
             )
 
-        if _state['debug'] and is_webengine:
+        if _settings['debug'] and is_webengine:
             # Initialise Remote debugging (need to be done only once)
             if not BrowserView.inspector_port:
                 BrowserView.inspector_port = BrowserView._get_debug_port()
@@ -369,7 +368,7 @@ class BrowserView(QMainWindow):
         self.cookies = {}
 
         if is_webengine:
-            if _state['private_mode']:
+            if _settings['private_mode']:
                 self.profile = QWebEngineProfile()
             else:
                 self.profile = QWebEngineProfile('pywebview')
@@ -380,12 +379,12 @@ class BrowserView(QMainWindow):
             cookie_store.cookieRemoved.connect(self.on_cookie_removed)
 
             self.webview.setPage(BrowserView.WebPage(self, profile=self.profile))
-        elif not is_webengine and not _state['private_mode']:
+        elif not is_webengine and not _settings['private_mode']:
             logger.warning('qtwebkit does not support private_mode')
 
-        user_agent = _state['user_agent']
-        # if user_agent and is_webengine:
-        #     self.profile.setHttpUserAgent(user_agent)
+        user_agent = _settings['user_agent']
+        if user_agent and is_webengine:
+            self.profile.setHttpUserAgent(user_agent)
 
         if is_webengine:
             self.profile.settings().setAttribute(
@@ -444,8 +443,8 @@ class BrowserView(QMainWindow):
             self.activateWindow()
             self.raise_()
 
-        if _state['icon']:
-            icon = QIcon(_state['icon'])
+        if _settings['icon']:
+            icon = QIcon(_settings['icon'])
             self.setWindowIcon(icon)
 
         self.pywebview_window.events.before_show.set()
@@ -642,16 +641,13 @@ class BrowserView(QMainWindow):
             uuid_ = BrowserView._convert_string(uuid)
 
             js_result = self._js_results[uuid_]
-
-            if js_result['parse_json'] and result:
-                try:
-                    js_result['result'] = json.loads(result)
-                except Exception:
-                    logger.exception('Failed to parse JSON: %s', result)
-                    js_result['result'] = result
-            else:
-                js_result['result'] = result
-
+            js_result['result'] = (
+                None
+                if result is None or result == 'null'
+                else result
+                if result == ''
+                else json.loads(result)
+            )
             js_result['semaphore'].release()
 
         try:  # < Qt5.6
@@ -673,7 +669,7 @@ class BrowserView(QMainWindow):
 
         self._set_js_api()
 
-        if _state['debug'] and settings['OPEN_DEVTOOLS_IN_DEBUG']:
+        if _settings['debug'] and settings['OPEN_DEVTOOLS_IN_DEBUG']:
             self.webview.show_inspector()
 
     def on_download_requested(self, download):
@@ -697,15 +693,18 @@ class BrowserView(QMainWindow):
         self.profile.cookieStore().deleteAllCookies()
 
     def get_current_url(self):
+        self.pywebview_window.events.loaded.wait()
         self.current_url_trigger.emit()
         self._current_url_semaphore.acquire()
 
         return self._current_url
 
     def load_url(self, url):
+        self.pywebview_window.events.loaded.clear()
         self.load_url_trigger.emit(url)
 
     def load_html(self, content, base_uri):
+        self.pywebview_window.events.loaded.clear()
         self.html_trigger.emit(content, base_uri)
 
     def create_confirmation_dialog(self, title, message):
@@ -775,10 +774,11 @@ class BrowserView(QMainWindow):
     def set_on_top(self, top):
         self.on_top_trigger.emit(top)
 
-    def evaluate_js(self, script, parse_json):
+    def evaluate_js(self, script):
+        self.pywebview_window.events.loaded.wait()
         result_semaphore = Semaphore(0)
         unique_id = uuid1().hex
-        self._js_results[unique_id] = {'semaphore': result_semaphore, 'result': '', 'parse_json': parse_json }
+        self._js_results[unique_id] = {'semaphore': result_semaphore, 'result': ''}
 
         self.evaluate_js_trigger.emit(script, unique_id)
         result_semaphore.acquire()
@@ -792,6 +792,8 @@ class BrowserView(QMainWindow):
         def _register_window_object():
             frame.addToJavaScriptWindowObject('external', self.js_bridge)
 
+        script = inject_pywebview(self.js_bridge.window, renderer)
+
         if is_webengine:
             qwebchannel_js = QtCore.QFile('://qtwebchannel/qwebchannel.js')
             if qwebchannel_js.open(QtCore.QFile.ReadOnly):
@@ -803,7 +805,12 @@ class BrowserView(QMainWindow):
             frame = self.webview.page().mainFrame()
             _register_window_object()
 
-        inject_pywebview(renderer, self.js_bridge.window)
+        try:
+            self.webview.page().runJavaScript(script)
+        except AttributeError:  # < QT 5.6
+            self.webview.page().mainFrame().evaluateJavaScript(script)
+
+        self.pywebview_window.events.loaded.set()
 
     @staticmethod
     def _convert_string(result):
@@ -845,8 +852,6 @@ class BrowserView(QMainWindow):
 def setup_app():
     # MUST be called before create_window and set_app_menu
     global _app
-    if settings['IGNORE_SSL_ERRORS']:
-        environ_append('QTWEBENGINE_CHROMIUM_FLAGS', '--ignore-certificate-errors')
     _app = QApplication.instance() or QApplication(sys.argv)
 
 
@@ -1059,10 +1064,10 @@ def create_file_dialog(dialog_type, directory, allow_multiple, save_filename, fi
         return i.create_file_dialog(dialog_type, directory, allow_multiple, save_filename, file_filter)
 
 
-def evaluate_js(script, uid, parse_json=True):
+def evaluate_js(script, uid):
     i = BrowserView.instances.get(uid)
     if i:
-        return i.evaluate_js(script, parse_json)
+        return i.evaluate_js(script)
 
 
 def get_position(uid):

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -375,6 +375,26 @@ class BrowserView:
 
             return cookies
 
+        def add_cookie(self, name: str, value: str, domain: str, path: str, 
+                        expires: float = None, secure: bool = False, 
+                        http_only: bool = False, same_site: str = None):
+            def _add_cookie():
+                self.browser.add_cookie(
+                    name,
+                    value,
+                    domain,
+                    path, 
+                    expires,
+                    secure, 
+                    http_only,
+                    same_site
+                )
+            if not is_chromium:
+                logger.error('add_cookie() is not implemented for this platform')
+                return
+            
+            self.Invoke(Func[Type](_add_cookie))
+
         def load_html(self, content, base_uri):
             def _load_html():
                 self.browser.load_html(content, base_uri)
@@ -783,6 +803,13 @@ def get_cookies(uid):
     if i:
         return i.get_cookies()
 
+def add_cookie(name, value, domain, path, expires, secure, http_only, same_site,uid):
+    if is_cef:
+        return CEF.add_cookie(name, value, domain, path, expires, secure, http_only, same_site, uid)
+    i = BrowserView.instances.get(uid)
+
+    if i:
+        return i.add_cookie(name, value, domain, path, expires, secure, http_only, same_site)
 
 def get_current_url(uid):
     if is_cef:

--- a/webview/webview.py
+++ b/webview/webview.py
@@ -1,0 +1,92 @@
+from enum import IntEnum
+from typing import Optional, Callable, Any
+import json
+import ctypes
+from ._webview_ffi import _webview_lib, _encode_c_string
+
+class SizeHint(IntEnum):
+    NONE = 0
+    MIN = 1
+    MAX = 2
+    FIXED = 3
+
+class Size:
+    def __init__(self, width: int, height: int, hint: SizeHint):
+        self.width = width
+        self.height = height
+        self.hint = hint
+
+class Webview:
+    def __init__(self, debug: bool = False, size: Optional[Size] = None, window: Optional[int] = None):
+        self._handle = _webview_lib.webview_create(int(debug), window)
+        self._callbacks = {}
+
+        if size:
+            self.size = size
+
+    @property
+    def size(self) -> Size:
+        return self._size
+
+    @size.setter
+    def size(self, value: Size):
+        _webview_lib.webview_set_size(self._handle, value.width, value.height, value.hint)
+        self._size = value
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    @title.setter
+    def title(self, value: str):
+        _webview_lib.webview_set_title(self._handle, _encode_c_string(value))
+        self._title = value
+
+    def destroy(self):
+        for name in list(self._callbacks.keys()):
+            self.unbind(name)
+        _webview_lib.webview_terminate(self._handle)
+        _webview_lib.webview_destroy(self._handle)
+        self._handle = None
+
+    def navigate(self, url: str):
+        _webview_lib.webview_navigate(self._handle, _encode_c_string(url))
+
+    def run(self):
+        _webview_lib.webview_run(self._handle)
+        self.destroy()
+
+    def bind(self, name: str, callback: Callable[..., Any]):
+        def wrapper(seq: bytes, req: bytes, arg: int):
+            args = json.loads(req.decode())
+            try:
+                result = callback(*args)
+                success = True
+            except Exception as e:
+                result = str(e)
+                success = False
+            self.return_(seq.decode(), 0 if success else 1, json.dumps(result))
+
+        c_callback = _webview_lib.CFUNCTYPE(None, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_void_p)(wrapper)
+        self._callbacks[name] = c_callback
+        _webview_lib.webview_bind(self._handle, _encode_c_string(name), c_callback, None)
+
+    def unbind(self, name: str):
+        if name in self._callbacks:
+            _webview_lib.webview_unbind(self._handle, _encode_c_string(name))
+            del self._callbacks[name]
+
+    def return_(self, seq: str, status: int, result: str):
+        _webview_lib.webview_return(self._handle, _encode_c_string(seq), status, _encode_c_string(result))
+
+    def eval(self, source: str):
+        _webview_lib.webview_eval(self._handle, _encode_c_string(source))
+
+    def init(self, source: str):
+        _webview_lib.webview_init(self._handle, _encode_c_string(source))
+
+if __name__ == "__main__":
+    wv = Webview()
+    wv.title = "Hello, World!"
+    wv.navigate("https://www.google.com")
+    wv.run()

--- a/webview/window.py
+++ b/webview/window.py
@@ -318,6 +318,25 @@ class Window:
         return self.gui.get_cookies(self.uid)
 
     @_loaded_call
+    def add_cookie(self, name: str, value: str, domain: str, path: str, 
+                        expires: float = None, secure: bool = False, 
+                        http_only: bool = False, same_site: str = None):
+        """
+        Clear all the cookies
+        """
+        return self.gui.add_cookie(
+            name,
+            value,
+            domain,
+            path, 
+            expires,
+            secure, 
+            http_only,
+            same_site,
+            self.uid
+            )
+
+    @_loaded_call
     def get_current_url(self) -> str | None:
         """
         Get the URL currently loaded in the target webview


### PR DESCRIPTION
Added the ability to add custom cookies to `EdgeChrome` on NT platforms. This can help in scenarios where the user wants to inject cookies from `requests` session into the current webview.

Example:
```python
window = webview.create_window('Hello world', 'https://example.com')
...
response = requests.post(login_url, data=payload)
...
for cookie in response.cookies:
    window.add_cookie(
        cookie.name,
        cookie.value,
        cookie.path,
        cookie.domain,
    )
```