### PR TITLE
Fix a short blank when closing the window

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -286,6 +286,7 @@ class BrowserView:
                 if is_cef:
                     CEF.shutdown()
                 elif is_chromium:
+                    self.hide()
                     self.browser.clear_user_data()
 
                 WinForms.Application.Exit()


### PR DESCRIPTION
In the latest github version, the user cache will be cleaned before closing the window, which will cause a short window blank phenomenon when closing the window. My modification method is to hide the window immediately when clicking the window button, and then perform cache cleanup and process termination in the background, so as to indirectly fix the window blank problem and improve the user experience.