### PR TITLE
[Cocoa] Don't terminate app if windows shouldn't close

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -59,9 +59,10 @@ class BrowserView:
 
     class AppDelegate(AppKit.NSObject):
         def applicationShouldTerminate_(self, app):
+            should_close = True
             for i in BrowserView.instances.values():
-                i.closing.set()
-            return Foundation.YES
+                should_close = should_close and BrowserView.should_close(i.pywebview_window)
+            return Foundation.YES if should_close else Foundation.NO
 
         def applicationSupportsSecureRestorableState_(self, app):
             return Foundation.YES


### PR DESCRIPTION
On Mac when quitting with Cmd+Q, the `closing` event and `confirm_close` dialog responses were being ignored, causing the app to quit even after the user said they don't want it to. This small change will keep the app running if any of the windows indicate they shouldn't be closed.