### PR TITLE
Update docs: fix broken link to renderer and a typo

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -62,7 +62,7 @@ Start a GUI loop and display previously created windows. This function must be c
 * `func` - function to invoke upon starting the GUI loop.
 * `args` - function arguments. Can be either a single value or a tuple of values.
 * `localization` - a dictionary with localized strings. Default strings and their keys are defined in localization.py
-* `gui` - force a specific GUI. Allowed values are `cef`, `qt` or `gtk` depending on a platform. See [Renderer](/guide/renderer.md) for details.
+* `gui` - force a specific GUI. Allowed values are `cef`, `qt` or `gtk` depending on a platform. See [Web Engine](/guide/web_engine.md) for details.
 * `debug` - enable debug mode. See [Debugging](/guide/debugging.md) for details.
 * `http_server` - enable built-in HTTP server for absolute local paths. For relative paths HTTP server is started automatically and cannot be disabled. For each window, a separate HTTP server is spawned. This option is ignored for non-local URLs.
 * `http_port` - specify a port number for the HTTP server. By default port is randomized.

--- a/docs/guide/interdomain.md
+++ b/docs/guide/interdomain.md
@@ -11,7 +11,7 @@
 
 Executing Python functions from Javascript can be done with two different mechanisms.
 
-- by exposing an instance of a Python class to the `js_api` parameter of `create_window`. All the callable methods of the class will be exposed to the JS domain as `pywebview.api.method_name` with correct parameter signatures. Method name must not start with an underscore. Nested classes are allowed and are converted into a nested objects in Javascript. Cclass attributes starting with an underscore are not exposed. See an [example](/examples/js_api.html).
+- by exposing an instance of a Python class to the `js_api` parameter of `create_window`. All the callable methods of the class will be exposed to the JS domain as `pywebview.api.method_name` with correct parameter signatures. Method name must not start with an underscore. Nested classes are allowed and are converted into a nested objects in Javascript. Class attributes starting with an underscore are not exposed. See an [example](/examples/js_api.html).
 
 - by passing your function(s) to window object's `expose(func)`. This will expose a function or functions to the JS domain as `pywebview.api.func_name`. Unlike JS API, `expose` allows to expose functions also at the runtime. If there is a name clash between JS API and exposed functions, the latter takes precedence. See an [example](/examples/expose.html).
 

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -21,7 +21,7 @@ second_window = webview.create_window('Second window', 'https://woot.fi')
 webview.start()
 ```
 
-_pywebview_ gives a choice of using several web renderers. To change a web renderer, set the `gui` parameter of the `start` function to the desired value (e.g `cef` or `qt`). See [Renderer](/guide/renderer.md) for details.
+_pywebview_ gives a choice of using several web renderers. To change a web renderer, set the `gui` parameter of the `start` function to the desired value (e.g `cef` or `qt`). See [Web Engine](/guide/web_engine.md) for details.
 
 
 ## Backend logic


### PR DESCRIPTION
## Issues
1. I noticed two places in docs where the link to renderer is broken.
2. Also a typo in docs/guide/interdomain.md

## Steps to reproduce
1. Navigate to https://pywebview.flowrl.com/guide/usage.html#basics
2. Click: See [Renderer](https://pywebview.flowrl.com/guide/renderer.html) for details
![Screenshot 2025-01-19 at 9 54 44 AM](https://github.com/user-attachments/assets/86202ca8-f422-4602-982e-f015c9446308)
![image](https://github.com/user-attachments/assets/7d5eeaa1-2c04-4fef-ad38-3cb45c2fa2c1)

Another place
1. Navigate to https://pywebview.flowrl.com/guide/api.html#webview-start
2. Click See [Renderer](https://pywebview.flowrl.com/guide/renderer.html) for details.
![Screenshot 2025-01-19 at 10 00 38 AM](https://github.com/user-attachments/assets/846e2e4e-0bdd-4ce7-bf40-bd5fa8f8d8c8)

## Proposed solution
I tried to fix it by linking to `web_engine.md`.