### PR TITLE
Support asyncio in exposed python methods

### DIFF
--- a/tests/test_expose.py
+++ b/tests/test_expose.py
@@ -1,4 +1,6 @@
 import webview
+import asyncio
+import threading
 
 from .util import assert_js, run_test
 
@@ -26,6 +28,19 @@ def test_override():
     window.expose(get_int)
     run_test(webview, window, expose_override)
 
+def test_asyncio():
+    loop = asyncio.new_event_loop()
+    window = webview.create_window('JSBridge test', html='<html><body>TEST</body></html>', event_loop=loop)
+    window.expose(get_async)
+
+    threading.Thread(target=loop.run_forever).start()
+    run_test(webview, window, expose_async)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+async def get_async():
+    await asyncio.sleep(1)
+    return 7331
 
 def get_int():
     return 420
@@ -56,3 +71,6 @@ def expose_runtime(window):
 
 def expose_override(window):
     assert_js(window, 'get_int', 420)
+
+def expose_async(window):
+    assert_js(window, 'get_async', 7331)

--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -18,6 +18,7 @@ import tempfile
 import threading
 from collections.abc import Iterable, Mapping
 from typing import Any, Callable
+from asyncio import AbstractEventLoop
 from uuid import uuid4
 
 from proxy_tools import module_property
@@ -255,6 +256,7 @@ def create_window(
     server: type[http.ServerType] = http.BottleServer,
     http_port: int | None = None,
     server_args: http.ServerArgs = {},
+    event_loop: AbstractEventLoop = None
 ) -> Window:
     """
     Create a web view window using a native GUI. The execution blocks after this function is invoked, so other
@@ -282,6 +284,7 @@ def create_window(
     :param transparent: Don't draw window background.
     :param server: Server class. Defaults to BottleServer
     :param server_args: Dictionary of arguments to pass through to the server instantiation
+    :param event_loop: Optional event loop to support exposing async functions
     :return: window object.
     """
 
@@ -324,6 +327,7 @@ def create_window(
         http_port=http_port,
         server_args=server_args,
         screen=screen,
+        event_loop=event_loop
     )
 
     windows.append(window)

--- a/webview/util.py
+++ b/webview/util.py
@@ -310,7 +310,7 @@ def js_bridge_call(window: Window, func_name: str, param: Any, value_id: str) ->
     if func is not None:
         try:
             func_params = param
-            thread = Thread(target=_call)
+            thread = Thread(target=_call, daemon=True)
             thread.start()
         except Exception:
             logger.exception(

--- a/webview/window.py
+++ b/webview/window.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import os
 from collections.abc import Mapping, Sequence
+from asyncio import AbstractEventLoop
 from enum import Flag, auto
 from functools import wraps
 from threading import Lock
@@ -111,7 +112,8 @@ class Window:
         http_port: int | None = None,
         server: type[http.ServerType] | None = None,
         server_args: http.ServerArgs = {},
-        screen: Screen = None
+        screen: Screen = None,
+        event_loop: AbstractEventLoop = None
     ) -> None:
         self.uid = uid
         self._title = title
@@ -142,6 +144,7 @@ class Window:
         self.localization_override = localization
         self.vibrancy = vibrancy
         self.screen = screen
+        self.event_loop = event_loop
 
         # Server config
         self._http_port = http_port


### PR DESCRIPTION
This commit adds support for coroutine methods 'async/await'. It does this by simply checking if an exposed method returns a coroutine and if so it awaits it.

This makes it fully backwards compatible, and is purely an enhancement.

Includes a simple test demonstrating how to use it. 

Fixes #801 #867 