### PR TITLE
[BUGFIX] multiwindow with local-url setups sets wrong server root (BottleServer)

### DIFF
--- a/webview/http.py
+++ b/webview/http.py
@@ -96,9 +96,9 @@ class BottleServer:
             common_path = '.'
         else:
             local_urls = [u.split('#')[0] for u in urls if is_local_url(u)]
-            common_path= os.path.commonpath(local_urls) if len(local_urls) > 0 else None
+            common_path = os.path.commonpath(local_urls) if len(local_urls) > 0 else None
             if common_path is not None and not os.path.isdir(abspath(common_path)):
-                common_path= os.path.dirname(common_path)
+                common_path = os.path.dirname(common_path)
             server.root_path = abspath(common_path) if common_path is not None else None
             logger.debug('HTTP server root path: %s' % server.root_path)
             app = bottle.Bottle()

--- a/webview/http.py
+++ b/webview/http.py
@@ -96,9 +96,9 @@ class BottleServer:
             common_path = '.'
         else:
             local_urls = [u.split('#')[0] for u in urls if is_local_url(u)]
-            common_path = (
-                os.path.dirname(os.path.commonpath(local_urls)) if len(local_urls) > 0 else None
-            )
+            common_path= os.path.commonpath(local_urls) if len(local_urls) > 0 else None
+            if common_path is not None and not os.path.isdir(abspath(common_path)):
+                common_path= os.path.dirname(common_path)
             server.root_path = abspath(common_path) if common_path is not None else None
             logger.debug('HTTP server root path: %s' % server.root_path)
             app = bottle.Bottle()


### PR DESCRIPTION
I was about to open an issue but then I thought i would just fix it and move on

## **ISSUE**
BottleServer class was determining server root wrong when multiple local-url windows were created:

I.E: creating two local-url windows pointing to files as follows:
**'C:/projects/web/index.html'**
**'C:/projects/web/splash.html'**
will set server root to **'C:/projects'** instead of **'C:/projects/web'**

## **CAUSE**
@ http.py - line 100 ->
`os.path.dirname(os.path.commonpath(local_urls)) if len(local_urls) > 0 else None`

For most cases, `os.path.commonpath()` already returns the required path (**'C:/projects/web'** in the example), using `os.path.dirname()` on it just make it go up another level, causing the issue

## **SOLUTION**
check if `os.path.commonpath()` already returned a dir and use that one if so, otherwise pass it trough `os.path.dirname()`

personally I see dirname() step unnecessary, but maybe there's a not-so-obvious reason for it to be there so I didn't removed it
