### PR TITLE
Resizable frameless window

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -531,16 +531,19 @@ class BrowserView:
                 _toggle()
 
         def resize(self, width, height, fix_point):
+            scaled_width = round(width * self.scale_factor)
+            scaled_height = round(height * self.scale_factor)
+
             x = self.Location.X
             y = self.Location.Y
 
             if fix_point & FixPoint.EAST:
-                x = x + self.Width - width
+                x = x + self.Width - scaled_width
 
             if fix_point & FixPoint.SOUTH:
-                y = y + self.Height - height
+                y = y + self.Height - scaled_height
 
-            windll.user32.SetWindowPos(self.Handle.ToInt32(), None, x, y, width, height, 64)
+            windll.user32.SetWindowPos(self.Handle.ToInt32(), None, x, y, scaled_width, scaled_height, 64)
 
         def move(self, x, y):
             SWP_NOSIZE = 0x0001  # Retains the current size

--- a/webview/util.py
+++ b/webview/util.py
@@ -352,7 +352,8 @@ def load_js_files(window: Window, platform: str) -> str:
                     'drag_selector': webview.DRAG_REGION_SELECTOR,
                     'zoomable': str(window.zoomable),
                     'draggable': str(window.draggable),
-                    'easy_drag': str(platform == 'edgechromium' and window.easy_drag and window.frameless)
+                    'easy_drag': str(platform == 'edgechromium' and window.easy_drag and window.frameless),
+                    'easy_resize': str(window.frameless and window.resizable),
                 }
             elif name == 'finish':
                 finish_script = content

--- a/webview/util.py
+++ b/webview/util.py
@@ -262,6 +262,10 @@ def js_bridge_call(window: Window, func_name: str, param: Any, value_id: str) ->
         window.move(*param)
         return
 
+    if func_name == 'pywebviewResizeWindow':
+        window.resize(*param)
+        return
+
     if func_name == 'pywebviewEventHandler':
         event = param['event']
         node_id = param['nodeId']

--- a/webview/window.py
+++ b/webview/window.py
@@ -359,7 +359,7 @@ class Window:
 
     @_shown_call
     def resize(
-        self, width: int, height: int, fix_point: FixPoint = FixPoint.NORTH | FixPoint.WEST
+        self, width: int, height: int, fix_point: FixPoint | int = FixPoint.NORTH | FixPoint.WEST
     ) -> None:
         """
         Resize window
@@ -370,6 +370,8 @@ class Window:
             with bitwise operators.
             Example: FixPoint.NORTH | FixPoint.WEST
         """
+        if not isinstance(fix_point, FixPoint):
+            fix_point = FixPoint(fix_point)
         self.gui.resize(width, height, self.uid, fix_point)
 
     @_shown_call


### PR DESCRIPTION
I really like this project and have been using it to create portable user interfaces for my Python projects. While deeply integrating `pywebview`, I found it frustrating that *frameless* windows are not resizable — although I understand this might be a limitation of frameless windows themselves.

I looked into how the code handles dragging for frameless windows. The process involves capturing `mousemove` events on the JavaScript side and then calling the `window.move` method through the `js_bridge`. Inspired by this, I thought it might be possible to make frameless windows resizable as well.

https://github.com/user-attachments/assets/ba885253-5f55-4fd1-85f4-a8c4863e0e0e

To implement resizable frameless windows, my approach is to capture mouse events in JavaScript, handle the resize logic there, and finally call the `window.resize` method. The process can be broken down into the following parts:

## 1. Properly handle DPI scaling in `window.resize`

I noticed that `webview/platforms/winforms.py` does not correctly handle the scale factor.

https://github.com/r0x0r/pywebview/blob/eccca484120ad004907f541c5b40e9f5903d2071/webview/platforms/winforms.py#L533-L543

The first commit fix this issue. (1e3257202289d12447f7553a2203ffd3c29a7645)

## 2. Expose `window.resize` to the JavaScript side

We modified the `resize` method to accept an `int` as the `fix_point` parameter (f9384245bb04fac31074f08e5a8d345ef526b5f3). Then, similar to the `move` method, we exposed it to the JavaScript side (f73634fdae7ae5015a75c8b1a9589c94ae62a67c).

## 3. Determine when to enable frameless resize

When both `window.frameless` and `window.resizable` are set, we pass a flag `easy_resize` to `customize.js` to activate frameless resize functionality. (cb222ec488f6a5cef722deae59a9b5d93196a377)

## 4. Implement the resize logic

This part involves several tasks:

1. Detect when the mouse is near the window edges.
2. Override the mouse cursor style accordingly.
3. Toggle the resizing state when the mouse is pressed or released.
4. Ensure it doesn’t interfere with the existing `easy_drag` functionality.

commit: (b328925226aab05232501d2080fccd767ceeb684)

## Limitations

When the page height exceeds the visible area, a native scrollbar appears on the left side of the window. The area covered by the scrollbar doesn't seem to respond to resize actions — possibly because the native scrollbar takes precedence?

Although resizable frameless windows are not a native feature, I think adding this could really make life a little easier.