### PR TITLE
create_file_dialog should return Sequence[str]

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -795,7 +795,7 @@ def create_file_dialog(dialog_type, directory, allow_multiple, save_filename, fi
 
             result = dialog.ShowDialog(i)
             if result == WinForms.DialogResult.OK:
-                file_path = dialog.FileName
+                file_path = (dialog.FileName,)
             else:
                 file_path = None
 


### PR DESCRIPTION
In `winforms.py`, the `create_file_dialog` function returns a string value that is not of type `Sequence[str] | None` when saving a file, which is inconsistent with its function signature.

https://github.com/r0x0r/pywebview/blob/02daa3ad41821a900b5c7e9bf5bec9d53614667a/webview/window.py#L502-L510

The issue comes from:

https://github.com/r0x0r/pywebview/blob/02daa3ad41821a900b5c7e9bf5bec9d53614667a/webview/platforms/winforms.py#L798