### PR TITLE
[Cocoa] Implement `OPEN_DEVTOOLS_IN_DEBUG`

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -384,6 +384,9 @@ class BrowserView:
 
                 inject_pywebview('cocoa', i.js_bridge.window)
 
+                if _state['debug'] and webview_settings['OPEN_DEVTOOLS_IN_DEBUG']:
+                    BrowserView._open_web_inspector(webview)
+
         # Handle JavaScript window.print()
         def userContentController_didReceiveScriptMessage_(self, controller, message):
             if message.body() == 'print':
@@ -1281,6 +1284,24 @@ class BrowserView:
         return _objc_so.PyObjCMethodSignature_WithMetaData(
             ctypes.create_string_buffer(signature_str), None, False
         )
+
+    @staticmethod
+    def _open_web_inspector(webview):
+        """
+        Programmatically open the Web Inspector for the given WKWebView.
+        Uses private WebKit APIs that may not work on all macOS versions.
+        """
+        try:
+            if hasattr(webview, '_inspector'):
+                inspector = webview._inspector()
+                if inspector and hasattr(inspector, 'show'):
+                    inspector.show()
+                    return True
+
+            return False
+
+        except Exception as e:
+            return False
 
     @staticmethod
     def quote(string):

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -638,7 +638,7 @@ class BrowserView:
 
         config.preferences().setValue_forKey_(webview_settings['ALLOW_FILE_URLS'], 'allowFileAccessFromFileURLs')
 
-        if _state['debug'] and webview_settings['OPEN_DEVTOOLS_IN_DEBUG']:
+        if _state['debug']:
             config.preferences().setValue_forKey_(True, 'developerExtrasEnabled')
 
         self.js_bridge = BrowserView.JSBridge.alloc().initWithObject_(window)


### PR DESCRIPTION
👋 noticed that `OPEN_DEVTOOLS_IN_DEBUG` wasn't taking effect on Cocoa unlike other GUIs like edgechromium and qt. Took a stab at implementing it, albeit with some private APIs which may or may not work - didn't see any public options available. This worked for me on macOS 15.4.1.

I'm a bit out of my depth here, but some AI assistance nudged that there could be some other possible fallback implementations as well:
```py
try:
    import objc
    _WKInspector = objc.lookUpClass('_WKInspector')
    if _WKInspector:
        inspector = _WKInspector.alloc()
        if hasattr(inspector, 'show'):
            inspector.show()
            return True
except:
    pass

try:
    if hasattr(webview, 'performSelector_'):
        selector_name = objc.selector(b'_showInspector', signature=b'v@:')
        webview.performSelector_(selector_name)
        return True
except:
    pass
```

I left these out given that I haven't tested them, but happy to add back if that's preferable.

Merging this into `6.0` since it's the branch I'm personally working on. I don't see any reason this couldn't be backported to `master` if you're planning another `5.x` release.