### PR TITLE
🛠️ Improve `cryptography` Dependency & PyPI Metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pywebview"
 authors = [{ name = "Roman Sirokov", email = "roman@flowrl.com" }]
+readme = { file = "README.md", content-type = "text/markdown", charset = "utf-8" }
 description = "Build GUI for your Python program with JavaScript, HTML, and CSS"
 keywords = ["gui", "webkit", "html", "web"]
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: User Interfaces",
@@ -40,6 +41,7 @@ dependencies = [
     "proxy_tools",
     "bottle",
     "typing_extensions",
+    "cryptography"
 ]
 dynamic = ["version"]
 
@@ -52,7 +54,6 @@ qt = ["QtPy", "PyQt6", "PyQt6-WebEngine"]
 qt5 = ["QtPy", "PyQt5", "pyqtwebengine"]
 qt6 = ["QtPy", "PyQt6", "PyQt6-WebEngine"]
 android = ["kivy", "jnius"]
-ssl = ["cryptography"]
 
 [project.urls]
 Homepage = "https://pywebview.flowrl.com/"


### PR DESCRIPTION
> [!IMPORTANT]  
> I used `pip install pywebview` to install this _"module"/library_

I'm making this pull request for two reasons.

1. When testing the [HTTP Server example](https://pywebview.flowrl.com/guide/usage.html#http-server), I ran:
 ```shell
   (.venv) D:\CODE\PYTHON\pywebview\test1>python app5.py
   Traceback (most recent call last):
     File "D:\CODE\PYTHON\pywebview\test1\app5.py", line 4, in <module>
       webview.start(ssl=True)
     File "D:\CODE\PYTHON\pywebview\test1\.venv\Lib\site-packages\webview\__init__.py", line 181, in start
       keyfile, certfile = __generate_ssl_cert()
                           ^^^^^^^^^^^^^^^^^^^^
     File "D:\CODE\PYTHON\pywebview\test1\.venv\Lib\site-packages\webview\__init__.py", line 346, in __generate_ssl_cert
       from cryptography import x509
   ModuleNotFoundError: No module named 'cryptography'
````

The simple fix was:

```bash
pip install cryptography
```

It would be helpful to mention this dependency (e.g. via `pywebview[ssl]`) in the guide and in `pyproject.toml`.

2. The use of the `ssl` extra is not explicitly mentioned in the example presented on the website.
   Since the example includes `ssl=True`, it might be clearer to show the full installation command as:

   ```bash
   pip install pywebview
   ```

   Therefore, I suggest moving `cryptography` from an optional extra to a main dependency, since it's needed by a default example.

---

Additionally, as an external contributor:

* I added a `README.md` entry in `pyproject.toml` so the full project description appears on PyPI.
* I included **Python 3.12** in the `classifiers` section of `pyproject.toml`, since I tested it successfully and it wasn’t listed originally.

Thank you for considering these suggestions!

— @tutosrive