### PR TITLE
Add `cocoa` to `GUIType`, accept all GUIs in `PYWEBVIEW_GUI` env var

### DIFF
--- a/webview/guilib.py
+++ b/webview/guilib.py
@@ -5,13 +5,14 @@ import os
 import platform
 import sys
 from types import ModuleType
-from typing import Any, Callable, cast
+from typing import Any, Callable, cast, get_args
 
 from typing_extensions import Literal, TypeAlias
 
 from webview import WebViewException
 
-GUIType: TypeAlias = Literal['qt', 'gtk', 'cef', 'mshtml', 'edgechromium', 'android']
+GUIType: TypeAlias = Literal['qt', 'gtk', 'cef', 'mshtml', 'edgechromium', 'android', 'cocoa']
+GUI_TYPES = list(get_args(GUIType))
 
 logger = logging.getLogger('pywebview')
 guilib: ModuleType | None = None
@@ -94,7 +95,7 @@ def initialize(forced_gui: GUIType | None = None):
             os.environ['PYWEBVIEW_GUI'].lower()
             if 'PYWEBVIEW_GUI' in os.environ
             and os.environ['PYWEBVIEW_GUI'].lower()
-            in ['qt', 'gtk', 'cef', 'mshtml', 'edgechromium']
+            in GUI_TYPES
             else forced_gui,
         )
 


### PR DESCRIPTION
I noticed that the `GUIType` type does not include all valid GUIs like `cocoa`. Within pywebview source this isn't an issue since Darwin logic often just defaults to Cocoa:

https://github.com/r0x0r/pywebview/blob/d018f1d87a08d90c4d11211881037d6e51a19e96/webview/guilib.py#L103-L107

However, I noticed this issue in userland writing my own logic involving `GUIType`. For consistently, it would be nice to include all valid targets.

Similarly, I also noticed that parsing logic for `PYWEBVIEW_GUI` only checks a handful of GUIs. I'm assuming this was accidental and fixed, though if we intentionally only want to support overrides for a handful of GUIs I can revert that change.