### PR TITLE
Added pyobjc-framework-UniformTypeIdentifiers dep to macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pyobjc-framework-Quartz;sys_platform=='darwin'",
     "pyobjc-framework-WebKit;sys_platform=='darwin'",
     "pyobjc-framework-security;sys_platform=='darwin'",
+    "pyobjc-framework-UniformTypeIdentifiers;sys_platform=='darwin'",
     "QtPy;sys_platform=='openbsd6'",
     "importlib_resources; python_version < '3.7'",
     "proxy_tools",


### PR DESCRIPTION
I encountered the problem, that I was not able to use the native Audio element from [gradio](https://www.gradio.app/) inside the webview.
It throws `libc++abi: terminating due to uncaught exception of type NSException`, reason being: `*** Terminating app due to uncaught exception 'OC_PythonException', reason '<class 'AttributeError'>: 'NoneType' object has no attribute 'typeWithMIMEType_''`.
So I looked around in their code, but they are just using an `<input type="file">` under the hood.

So seeing the code [here](https://github.com/r0x0r/pywebview/blob/b0627e3026c2752e791773a753d387f938000b88/webview/platforms/cocoa.py#L942), I kind of figured that `import UniformTypeIdentifiers` fails on my Mac somehow.

After running `pip install pyobjc-framework-UniformTypeIdentifiers` the error disappeared. So my guess is, that it is missing by default in the `pyproject.toml`.

Maybe there is something else to be done, but this is just a simple PR as a notification.