### PR TITLE
Add webview2_runtime_path parameter for custom WebView2 runtime support

### DIFF
--- a/webview/__init__.py
+++ b/webview/__init__.py
@@ -115,6 +115,7 @@ settings = ImmutableDict({
     'REMOTE_DEBUGGING_PORT': None,
     'IGNORE_SSL_ERRORS': False,
     'SHOW_DEFAULT_MENUS': True,
+    'WEBVIEW2_RUNTIME_PATH': None,
 })
 
 

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -12,7 +12,7 @@ from threading import Event, Semaphore
 
 import clr
 
-from webview import FileDialog, _state, windows
+from webview import FileDialog, _state, settings, windows
 from webview.guilib import forced_gui_
 from webview.menu import Menu, MenuAction, MenuSeparator
 from webview.screen import Screen
@@ -46,6 +46,9 @@ def _is_new_version(current_version: str, new_version: str) -> bool:
 
 
 def _is_chromium():
+    if settings['WEBVIEW2_RUNTIME_PATH']:
+        return True
+
     def edge_build(key_type, key, description=''):
         try:
             windows_key = None


### PR DESCRIPTION
Adds support for specifying a custom WebView2 runtime path, useful for bundled applications with embedded WebView2 runtime instead of relying on system-installed runtime.

Changes:
- webview.__init__.start(): Add webview2_runtime_path parameter
- webview.guilib: Store webview2_runtime_path_ as module-level state
- webview.platforms.winforms._is_chromium(): Check custom runtime path before falling back to Windows registry check
- webview.platforms.edgechromium.EdgeChrome: Set BrowserExecutableFolder if custom runtime path is provided

This enables:
- Bundled applications to ship with specific WebView2 versions
- Corporate environments without system WebView2 installed
- Version-controlled WebView2 runtime for reproducible builds

Example usage:
  webview.start( webview2_runtime_path=r'C:\MyApp\webview2\Microsoft.WebView2.FixedVersionRuntime.114.0.1823.86.x64' )