### PR TITLE
Fix the navigation in docs (guide, usage and architecture)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,3 +1,7 @@
+---
+next: /guide/installation
+---
+
 # Introduction
 
 _pywebview_ is a lightweight native webview wrapper that allows to display HTML content in its own native GUI window. It gives you power of web technologies in your desktop application, hiding the fact that GUI is browser based. _pywebview_ ships with a built-in HTTP server, DOM support in Python and window management functionality.

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,3 +1,7 @@
+---
+prev: /guide/usage
+---
+
 # Application architecture
 
 There are several way to build your application using _pywebview_:

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -1,3 +1,7 @@
+---
+next: /guide/architecture
+---
+
 # Usage
 
 ## Basics


### PR DESCRIPTION
The /guide was redirecting to itself.