### PR TITLE
qt: support REMOTE_DEBUGGING_PORT

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -126,7 +126,7 @@ Additional options that override default behaviour of _pywebview_ to address pop
 * `IGNORE_SSL_ERRORS` Ignore SSL errors. Disabled by default.
 * `OPEN_EXTERNAL_LINKS_IN_BROWSER`. Open `target=_blank` link in an external browser. Enabled by default.
 * `OPEN_DEVTOOLS_IN_DEBUG` Open devtools automatically in debug mode. Enabled by default.
-* `REMOTE_DEBUGGING_PORT` Enable remote debugging when using `edgechromium`. Disabled by default.* `SHOW_DEFAULT_MENUS` Show default menu on Cocoa. Enabled by default.
+* `REMOTE_DEBUGGING_PORT` Enable remote debugging when using `edgechromium` or `qt`. Disabled by default.* `SHOW_DEFAULT_MENUS` Show default menu on Cocoa. Enabled by default.
 * `SHOW_DEFAULT_MENUS` Show default menus on Cocoa. Enabled by default.
 * `WEBVIEW2_RUNTIME_PATH` Path to WebView2 runtime. You can use relative paths, which will be resolved relative to the application entry point with support of path resolution for most bundlers. If not set, the system installed runtime is used if present.
 

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -13,7 +13,7 @@ This will enable web inspector on macOS, GTK and QT (QTWebEngine only). To open 
 
 Debugging Python code on Android is not possible apart from printing message to `logcat`. Use `adb -s <DEVICE_ID> logcat | grep python` for displaying log messages related to Python. Frontend code can be debugged with WebView remote debugging. Refer to [this guide](https://developer.chrome.com/docs/devtools/remote-debugging/webviews/) for details.
 
-Remote debugging is supported with the `edgechromium` renderer. To take remote debugging into use set `webview.settings['REMOTE_DEBUGGING_PORT']` to the port number you wish to run a debugger on.
+Remote debugging is supported with the `edgechromium` and `qt` renderers. To take remote debugging into use set `webview.settings['REMOTE_DEBUGGING_PORT']` to the port number you wish to run a debugger on.
 
 There is no way to attach an external debugger to MSHTML. The `debug` flag enables Javascript error reporting and right-click context menu.
 

--- a/webview/platforms/qt.py
+++ b/webview/platforms/qt.py
@@ -905,6 +905,11 @@ def setup_app():
     global _app
     if settings['IGNORE_SSL_ERRORS']:
         environ_append('QTWEBENGINE_CHROMIUM_FLAGS', '--ignore-certificate-errors')
+    if settings['REMOTE_DEBUGGING_PORT']:
+        environ_append(
+            'QTWEBENGINE_CHROMIUM_FLAGS',
+            f'--remote-debugging-port={settings["REMOTE_DEBUGGING_PORT"]}',
+        )
     _app = QApplication.instance() or QApplication(sys.argv)
 
 


### PR DESCRIPTION
This adds support `REMOTE_DEBUGGING_PORT` to the qt platform

I have tested it under qt5 - it is working (but have some internal qt5 bug when you're trying to type into input fields, otherwise everything seems working ok)
qt6 - working as expected