### PR TITLE
Fix macOS drag handler

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -498,7 +498,7 @@ class BrowserView:
                 if not _state['debug']:
                     return
 
-            super(BrowserView.WebKitHost, self).mouseDown_(event)
+            super(BrowserView.WebKitHost, self).mouseDragged_(event)
 
         def willOpenMenu_withEvent_(self, menu, event):
             if not _state['debug']:


### PR DESCRIPTION
This fixes a bug in the Cocoa implementation. Currently, `WebKitHost.mouseDragged_` events are being incorrectly forwarded to `super(...).mouseDown_`.