### PR TITLE
Release retained Cocoa objects to fix “ghost” windows

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -108,6 +108,12 @@ class BrowserView:
             i.webview.removeFromSuperview()
             i.webview = None
 
+            # release everything we retained in __init__
+            i._browserDelegate.release()
+            i._windowDelegate.release()
+            i._appDelegate.release()
+            i.window.release()
+
             i.closed.set()
             if BrowserView.instances == {}:
                 BrowserView.app.stop_(self)


### PR DESCRIPTION
After updating to macOS Tahoe, I noticed a weird bug with secondary windows. When I'd close them, they'd visually disappear, but I'd then run into issues where I couldn't click on certain parts of the screen. It turned out the windows weren't actually closing; they were just becoming invisible:

https://github.com/user-attachments/assets/f46915b4-d8c3-4ff1-8aa8-365f197363c3



## Root cause
Inside `BrowserView.__init__`, several Cocoa objects are explicitly retained (`NSWindow`, `WKWebView`, and delegates), but are never released. A closed-but-retained `NSWindow` is removed from the screen, but not deallocated. This results in a ghost window, as seen in the above video.

## Solution
Release the retained objects when the window is closed, inside `windowWillClose_`.

## Note
I'm honestly not entirely convinced explicitly retaining the objects in `__init__` is necessary to begin with, since `BrowserView` keeps strong Python references to these objects. Unless I'm missing something, `pyobjc` automatically handles the retain/release cycle behind the scenes ([source](https://github.com/ronaldoussoren/pyobjc/blob/main/docs/dev/structure.rst#reference-counts)).

I kept the init code as is, though, to preserve existing logic. The decision to switch away from explicit retains can be made at a future date.