### PR TITLE
Optionally set icon in WinForms

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -225,12 +225,15 @@ class BrowserView:
             self.old_state = self.WindowState
 
             # Application icon
-            handle = kernel32.GetModuleHandleW(None)
-            icon_handle = windll.shell32.ExtractIconW(handle, sys.executable, 0)
+            if _state['icon'] and os.path.isfile(_state['icon']):
+                self.Icon = Icon(_state['icon'])
+            else:
+                handle = kernel32.GetModuleHandleW(None)
+                icon_handle = windll.shell32.ExtractIconW(handle, sys.executable, 0)
 
-            if icon_handle != 0:
-                self.Icon = Icon.FromHandle(IntPtr.op_Explicit(Int32(icon_handle))).Clone()
-                windll.user32.DestroyIcon(icon_handle)
+                if icon_handle != 0:
+                    self.Icon = Icon.FromHandle(IntPtr.op_Explicit(Int32(icon_handle))).Clone()
+                    windll.user32.DestroyIcon(icon_handle)
 
             self.closed = window.events.closed
             self.closing = window.events.closing


### PR DESCRIPTION
This PR allows to set an icon using `webview.start(icon=<file_path>)` when the platform is WinForms (i.e. default on Windows).

This is implemented in a similar fashion as for the [Qt](https://github.com/paco-sevilla/pywebview/blob/master/webview/platforms/qt.py#L499-L501) and [GTK](https://github.com/paco-sevilla/pywebview/blob/master/webview/platforms/gtk.py#L250-L252), with the difference that we check whether `_state['icon']` exists (and is a file).
This makes sure that the icon set when freezing an app can be used without having to bundle its file.
I hope this addresses the concerns raised in https://github.com/r0x0r/pywebview/pull/1665 and https://github.com/r0x0r/pywebview/issues/1411.

**Background/Rationale:** At the company where I work, we don't freeze our (internal) apps, but we deploy them to a Python Registry and install them with [`uv tools install`](https://docs.astral.sh/uv/guides/tools/#installing-tools). This allows us to deploy a single (pure-Python) package for both Windows and Linux users.
Even for people that freeze their apps, I think it would be nice if they could show the icon during development (on Windows).