### PR TITLE
Set icon in Cocoa platform

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -632,6 +632,10 @@ class BrowserView:
 
         self.datastore = WebKit.WKWebsiteDataStore.defaultDataStore()
 
+        if _state['icon'] and os.path.isfile(_state['icon']):
+            ns_image = AppKit.NSImage.alloc().initByReferencingFile_(_state['icon'])
+            BrowserView.app.setApplicationIconImage_(ns_image)
+
         if _state['private_mode']:
             # nonPersisentDataStore preserves cookies for some unknown reason. For this reason we use default datastore
             # and clear all the cookies beforehand


### PR DESCRIPTION
Similar to #1755 but for the Cocoa platform.
This change allows setting a Dock icon on macOS using `webview.start(icon=<file_path>)` (tested on Sonoma).
The `<file_path>` has to be an `*.icns` file for this to work.

We only set the icon if the file exists (and is a file). This makes sure that an icon set when freezing an app can be used without having to bundle it.