### PR TITLE
Change registry key query for theme detection

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -317,7 +317,7 @@ class BrowserView:
                     0,
                     winreg.KEY_READ,
                 )
-                system_theme, _ = winreg.QueryValueEx(personalize_key, 'SystemUsesLightTheme')
+                system_theme, _ = winreg.QueryValueEx(personalize_key, 'AppsUseLightTheme')
                 winreg.CloseKey(personalize_key)
                 if system_theme == 0:
                     return True


### PR DESCRIPTION
For non-system applications, using AppsUseLightTheme would be more appropriate.