### PR TITLE
Fix/remove redundant retain release

### DIFF
--- a/tests/test_app_delegate.py
+++ b/tests/test_app_delegate.py
@@ -1,0 +1,75 @@
+"""
+Test that NSApp.delegate is cleared when the owning window closes.
+
+NSApp.delegate uses assign semantics per Apple's documentation —
+delegating objects do not retain their delegates. The caller is
+responsible for ensuring the delegate remains alive. In multi-window
+scenarios, if the window whose appDelegate is the current NSApp.delegate
+closes while other windows remain open, pywebview must clear
+NSApp.delegate to avoid leaving a pointer to a delegate that may be
+freed.
+"""
+
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != 'darwin', reason='NSApp.delegate is macOS only')
+
+
+def test_app_delegate_cleared_when_owning_window_closes():
+    """When a child window whose appDelegate is NSApp.delegate closes
+    while the parent is still open, NSApp.delegate must be cleared.
+
+    Without this, NSApp.delegate points to a delegate whose owning
+    BrowserView has been destroyed. Per Apple's docs, delegate properties
+    use assign semantics — the delegating object does not retain the
+    delegate, so the caller must ensure it stays alive. Clearing the
+    pointer on close upholds this contract.
+    """
+    import objc
+
+    import webview
+    from webview.platforms.cocoa import BrowserView
+
+    result = {}
+
+    def check_delegate(parent):
+        parent.events.loaded.wait(timeout=10)
+
+        child = webview.create_window(
+            'Child',
+            html='<html><body>child</body></html>',
+        )
+        child.events.loaded.wait(timeout=10)
+
+        delegate_before = BrowserView.app.delegate()
+        result['before_addr'] = objc.pyobjc_id(delegate_before) if delegate_before else 0
+        del delegate_before
+
+        child.destroy()
+        time.sleep(0.5)
+
+        delegate_after = BrowserView.app.delegate()
+        after_addr = objc.pyobjc_id(delegate_after) if delegate_after else 0
+        result['after_addr'] = after_addr
+        result['still_points_to_child'] = after_addr == result['before_addr'] and after_addr != 0
+        del delegate_after
+
+        parent.destroy()
+
+    parent = webview.create_window(
+        'Parent',
+        html='<html><body>parent</body></html>',
+    )
+    webview.start(check_delegate, parent, debug=False)
+
+    assert not result.get('still_points_to_child', False), (
+        f"NSApp.delegate still points to closed child window's delegate "
+        f'(addr {result.get("before_addr", "?"):#x}). '
+        f'Per Apple docs, delegate properties use assign semantics — '
+        f'the delegating object does not retain the delegate. '
+        f'Leaving this pointer after the owning BrowserView is destroyed '
+        f'risks a use-after-free crash.'
+    )

--- a/tests/test_window_release.py
+++ b/tests/test_window_release.py
@@ -1,0 +1,129 @@
+"""
+Test that BrowserView sets releasedWhenClosed to False.
+
+NSWindow defaults to releasedWhenClosed=YES, which means Cocoa silently
+releases the window when it closes.  BrowserView.__init__ also calls
+.retain() on the window and windowWillClose_ calls .release() — a
+balanced pair.  But with releasedWhenClosed=YES, Cocoa adds an untracked
+third release on close, eventually over-releasing the window to rc=0.
+
+The freed memory is later accessed by a stale Cocoa callback (e.g. from
+WebKit's async IPC), triggering a pointer authentication trap (SIGTRAP)
+on ARM64 — a hard crash, not a catchable exception.
+
+Confirmed via lldb: setting a breakpoint on [NSWindow dealloc] shows the
+window being deallocated (dealloc called twice on the same address due
+to the over-release), followed by a crash when object_getClass accesses
+the freed address.
+
+The fix: setReleasedWhenClosed_(False) after window creation.
+"""
+
+import inspect
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != 'darwin', reason='NSWindow is macOS only')
+
+
+def test_pywebview_disables_released_when_closed():
+    """BrowserView.__init__ must call setReleasedWhenClosed_(False)."""
+    from webview.platforms.cocoa import BrowserView
+
+    source = inspect.getsource(BrowserView.__init__)
+    assert 'setReleasedWhenClosed_(False)' in source
+
+
+@pytest.mark.skipif(not shutil.which('lldb'), reason='lldb not available')
+def test_no_double_dealloc_on_window_close():
+    """Verify [NSWindow dealloc] is not called on a window that was already
+    deallocated.  Without setReleasedWhenClosed_(False), the window is
+    over-released: Cocoa's releasedWhenClosed auto-release plus pywebview's
+    manual .release() in windowWillClose_ cause a double dealloc, which
+    leads to a SIGTRAP when a stale callback accesses the freed memory.
+
+    This test runs the multi-window test sequence under lldb with a
+    breakpoint on [NSWindow dealloc] and verifies:
+      1. No crash (exit code 0)
+      2. No address appears in more than one dealloc
+    """
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.log', delete=False) as f:
+        logfile = f.name
+
+    try:
+        result = subprocess.run(
+            [
+                'lldb',
+                '--batch',
+                '-o',
+                'breakpoint set -n "-[NSWindow initWithContentRect:styleMask:backing:defer:]" '
+                "-C \"script print('ALLOC:'+hex(lldb.frame.FindRegister('x0').GetValueAsUnsigned()))\" "
+                '-G true',
+                '-o',
+                'breakpoint set -n "-[NSWindow dealloc]" '
+                "-C \"script print('DEALLOC:'+hex(lldb.frame.FindRegister('x0').GetValueAsUnsigned()))\" "
+                '-G true',
+                '-o',
+                'process launch -- -m pytest --no-header -q '
+                'tests/test_multi_window.py::test_bg_color '
+                'tests/test_multi_window.py::test_load_html '
+                'tests/test_multi_window.py::test_load_url',
+                '-k',
+                'script print("CRASH:"+hex(lldb.frame.FindRegister("x0").GetValueAsUnsigned()))',
+                '-k',
+                'quit',
+                '--',
+                sys.executable,
+            ],
+            capture_output=True,
+            timeout=180,
+            text=True,
+        )
+
+        output = result.stdout + result.stderr
+
+        # Collect alloc, dealloc, and crash events in order
+        events = []
+        crash_addr = None
+        for line in output.splitlines():
+            if line.startswith('ALLOC:'):
+                events.append(('alloc', line.split(':')[1]))
+            elif line.startswith('DEALLOC:'):
+                events.append(('dealloc', line.split(':')[1]))
+            elif line.startswith('CRASH:'):
+                crash_addr = line.split(':')[1]
+
+        # With the fix: no crash
+        assert (
+            crash_addr is None
+        ), f'Window at {crash_addr} was accessed after dealloc.\nEvents: {events}'
+        assert result.returncode == 0, (
+            f'Process exited with {result.returncode}.\n'
+            f'Events: {events}\n'
+            f'Output (last 500 chars): {output[-500:]}'
+        )
+
+        # Check no address is deallocated without a preceding alloc.
+        # An address that is deallocated, then allocated again, then
+        # deallocated again is fine (address reuse).  But dealloc
+        # without a matching alloc, or two deallocs in a row, indicates
+        # an over-release.
+        live = set()  # addresses that have been allocated but not yet deallocated
+        for event, addr in events:
+            if event == 'alloc':
+                live.add(addr)
+            elif event == 'dealloc':
+                assert addr in live, (
+                    f'Window {addr} deallocated without a preceding alloc '
+                    f'(double dealloc / over-release).\n'
+                    f'Events: {events}'
+                )
+                live.discard(addr)
+
+    finally:
+        os.unlink(logfile)

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -101,18 +101,14 @@ class BrowserView:
 
             i.webview.setNavigationDelegate_(None)
             i.webview.setUIDelegate_(None)
+            if BrowserView.app.delegate() == i._appDelegate:
+                BrowserView.app.setDelegate_(None)
 
             # this seems to be a bug in WkWebView, so we need to load blank html
             # see https://stackoverflow.com/questions/27410413/wkwebview-embed-video-keeps-playing-sound-after-release
             i.webview.loadHTMLString_baseURL_('', None)
             i.webview.removeFromSuperview()
             i.webview = None
-
-            # release everything we retained in __init__
-            i._browserDelegate.release()
-            i._windowDelegate.release()
-            i._appDelegate.release()
-            i.window.release()
 
             i.closed.set()
             if BrowserView.instances == {}:
@@ -589,14 +585,8 @@ class BrowserView:
 
         self.menu = window.menu or _state['menu']
 
-        # The allocated resources are retained because we would explicitly delete
-        # this instance when its window is closed
-        self.window = (
-            BrowserView.WindowHost.alloc()
-            .initWithContentRect_styleMask_backing_defer_(
-                rect, window_mask, AppKit.NSBackingStoreBuffered, False
-            )
-            .retain()
+        self.window = BrowserView.WindowHost.alloc().initWithContentRect_styleMask_backing_defer_(
+            rect, window_mask, AppKit.NSBackingStoreBuffered, False
         )
         self.window.setReleasedWhenClosed_(False)
         self.pywebview_window.native = self.window
@@ -613,14 +603,12 @@ class BrowserView:
         self.window.setFrame_display_(frame, True)
 
         config = WebKit.WKWebViewConfiguration.alloc().init()
-        self.webview = (
-            BrowserView.WebKitHost.alloc().initWithFrame_configuration_(rect, config).retain()
-        )
+        self.webview = BrowserView.WebKitHost.alloc().initWithFrame_configuration_(rect, config)
         self.webview.pywebview_window = window
 
-        self._browserDelegate = BrowserView.BrowserDelegate.alloc().init().retain()
-        self._windowDelegate = BrowserView.WindowDelegate.alloc().init().retain()
-        self._appDelegate = BrowserView.AppDelegate.alloc().init().retain()
+        self._browserDelegate = BrowserView.BrowserDelegate.alloc().init()
+        self._windowDelegate = BrowserView.WindowDelegate.alloc().init()
+        self._appDelegate = BrowserView.AppDelegate.alloc().init()
 
         BrowserView.app.setDelegate_(self._appDelegate)
         self.webview.setUIDelegate_(self._browserDelegate)

--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -598,6 +598,7 @@ class BrowserView:
             )
             .retain()
         )
+        self.window.setReleasedWhenClosed_(False)
         self.pywebview_window.native = self.window
 
         self.window.focus = window.focus


### PR DESCRIPTION
Stacked on PR https://github.com/r0x0r/pywebview/pull/1799 (setReleasedWhenClosed fix).

The manual .retain() in __init__ and .release() in windowWillClose_ on
the window, webview, and delegate objects are unnecessary — pyobjc
already manages their retain counts through the Python proxy. The
webview .retain() was never matched by a .release() at all (only
i.webview = None), making it a leak.

Also clear NSApp.delegate when the owning BrowserView's window closes,
if it still points to our delegate. NSApp.delegate uses assign semantics
per Apple's documentation — delegating objects do not retain their
delegates, and the caller is responsible for ensuring the delegate
stays alive. In practice, the delegate's retain count is influenced by
references internal to Cocoa (e.g. notification observer registration)
that are opaque and untraceable — they bypass all public retain/release
entry points and cannot be monitored via lldb breakpoints. Because
these internal retains are outside our control, it is impossible to
prove the delegate will be freed without clearing the pointer, but
equally impossible to prove it won't be. We follow Apple's documented
contract and clear the pointer.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>