### PR TITLE
fix transparent

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -759,12 +759,15 @@ def create_window(window):
             # hack to make transparent window work
             # window is started hidden and shown on Navigating event.
             # no idea why this works
-            browser.Opacity = 0
-            def on_loaded():
-                browser.Opacity = 1
-                window.hide()
-                window.show()
-            window.events.loaded += on_loaded
+            def on_shown():
+                _user32 = ctypes.windll.user32
+                _hwnd = window.native.Handle.ToInt32()
+                
+                _style = _user32.GetWindowLongW(_hwnd,-20)
+                _user32.SetWindowLongW(_hwnd,-20,_style | 0x80000)
+
+                _user32.SetLayeredWindowAttributes(_hwnd,0,180,0x2)
+            window.events.shown  += on_shown
         else:
             browser.Show()
 

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -759,8 +759,12 @@ def create_window(window):
             # hack to make transparent window work
             # window is started hidden and shown on Navigating event.
             # no idea why this works
-            browser.Show()
-            browser.Hide()
+            browser.Opacity = 0
+            def on_loaded():
+                browser.Opacity = 1
+                window.hide()
+                window.show()
+            window.events.loaded += on_loaded
         else:
             browser.Show()
 


### PR DESCRIPTION
My idea was to move the operation to the window.events.loaded event. This successfully resolved the transparency and flickering issues, though I’m not sure whether it works on other system versions as well.

```python
import webview

html='<body style="background-color: transparent; color: dark;"><h1>Hello</h1></body>'

if __name__ == '__main__':
    webview.create_window(
        'Transparent window', html=html, transparent=True, frameless=True
    )
    webview.start()
```