### PR TITLE
[Cocoa] fix window coordinates on multi-monitor setups

### DIFF
--- a/webview/platforms/cocoa.py
+++ b/webview/platforms/cocoa.py
@@ -53,6 +53,12 @@ logger.debug('Using Cocoa')
 renderer = 'wkwebview'
 
 
+def _primary_screen_height():
+    """Height of the primary screen, ie. screens()[0], not the focused mainScreen()."""
+    screens = AppKit.NSScreen.screens()
+    return screens[0].frame().size.height if screens else 0
+
+
 class BrowserView:
     instances = {}
     app = AppKit.NSApplication.sharedApplication()
@@ -151,8 +157,7 @@ class BrowserView:
             i = BrowserView.get_instance('window', notification.object())
             if i:
                 frame = i.window.frame()
-                screen = i.window.screen().frame()
-                flipped_y = screen.size.height - frame.size.height - frame.origin.y
+                flipped_y = _primary_screen_height() - frame.origin.y - frame.size.height
                 i.pywebview_window.events.moved.set(frame.origin.x, flipped_y)
 
     class JSBridge(AppKit.NSObject):
@@ -667,7 +672,9 @@ class BrowserView:
         self.window.setFrameOrigin_(self.screen.origin)
 
         if window.initial_x is not None and window.initial_y is not None:
-            self.move(window.initial_x, window.initial_y)
+            # initial_x / initial_y are relative to the target screen, move expects absolute
+            screen_top = _primary_screen_height() - self.screen.origin.y - self.screen.size.height
+            self.move(self.screen.origin.x + window.initial_x, screen_top + window.initial_y)
         else:
             self.center()
 
@@ -809,10 +816,7 @@ class BrowserView:
         AppHelper.callAfter(self.window.deminiaturize_, self)
 
     def move(self, x, y):
-        flipped_y = self.screen.size.height - y
-        self.window.setFrameTopLeftPoint_(
-            AppKit.NSPoint(self.screen.origin.x + x, self.screen.origin.y + flipped_y)
-        )
+        self.window.setFrameTopLeftPoint_(AppKit.NSPoint(x, _primary_screen_height() - y))
 
     def center(self):
         window_frame = self.window.frame()
@@ -1569,15 +1573,9 @@ def evaluate_js(script, uid, parse_json=True):
 
 def get_position(uid):
     def _position(coordinates):
-        screen_frame = i.screen
-
-        if screen_frame is None:
-            raise RuntimeError('Failed to obtain screen')
-
-        window = i.window
-        frame = window.frame()
+        frame = i.window.frame()
         coordinates[0] = int(frame.origin.x)
-        coordinates[1] = int(screen_frame.size.height - frame.origin.y - frame.size.height)
+        coordinates[1] = int(_primary_screen_height() - frame.origin.y - frame.size.height)
         semaphore.release()
 
     coordinates = [None, None]


### PR DESCRIPTION
Fixes #1820.

`move()` added the cached screen's origin to coordinates that are already absolute. The drag region JS sends `ev.screenX / ev.screenY`, and `get_position` already returned absolute x, so the two disagreed. With one monitor the origin is (0, 0) and the bug is invisible.

All in `cocoa.py`:

- `move()`: pass x through, flip y against the primary screen instead of the cached one.
- `get_position()` and the `moved` event: flip y against the primary screen too, so a move round-trips. Both used the cached screen height without its origin, wrong on any screen whose origin is not (0, 0).
- initial placement: add the target screen's origin at the call site, so `create_window(screen=..., x=..., y=...)` stays relative to that screen. Same split as qt (`qt.py:490` vs `qt.py:686`).
- `_primary_screen_height()`: `NSScreen.mainScreen()` is the screen holding the key window, not the primary one, so it cannot be used for the flip. The primary is `NSScreen.screens()[0]`, which is what WebKit flips `screenX / screenY` against.

Dropped the `Failed to obtain screen` guard in `get_position`, it no longer reads `i.screen`.

## Testing

macOS 26.5, Python 3.13, primary 1728x1117 at (0, 0), secondary 1920x1080 at (-1920, 213). Window created on the secondary monitor, then moved with the absolute coordinates the drag JS sends:

| | before | after | expected |
| --- | --- | --- | --- |
| `move(-1720, 124)` landed at | (-2280, -52) | (-1720, 124) | (-1720, 124) |
| `moved` event payload | (-2280, -89) | (-1720, 124) | (-1720, 124) |
| `window.x` / `window.y` after `x=100, y=100` | (-1820, -113) | (-1820, -76) | (-1820, -76) |

y is off by 176, the secondary screen's offset from the primary's top, so the y axis is affected as well. The raw x double count is -3640, clamped to -2280 by AppKit's on-screen constraint. The 37px reporting error is the primary height minus the cached screen height.

`center()` is unaffected: identical AppKit origin before and after, only its reported position changes, from (-1160, 177) to (-1160, 214), and 214 is the correct value.

`pytest tests/test_move_window.py tests/test_screens.py tests/test_multi_window.py tests/test_frameless.py tests/test_fullscreen.py tests/test_state.py tests/test_start.py`: 36 passed, with one monitor and with two.

gtk adds the screen origin the same way at `gtk.py:534`. Left alone, I have no way to test it.
