### PR TITLE
Marshal Form.TopMost to the GUI thread in the WinForms backend

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -666,6 +666,15 @@ class BrowserView:
 
             self.Invoke(Func[Type](_restore))
 
+        def set_on_top(self, on_top):
+            def _set_on_top():
+                self.TopMost = on_top
+
+            if self.InvokeRequired:
+                self.Invoke(Func[Type](_set_on_top))
+            else:
+                _set_on_top()
+
     @staticmethod
     def alert(message):
         WinForms.MessageBox.Show(str(message))
@@ -1009,7 +1018,7 @@ def toggle_fullscreen(uid):
 def set_on_top(uid, on_top):
     i = BrowserView.instances.get(uid)
     if i:
-        i.TopMost = on_top
+        i.set_on_top(on_top)
 
 
 def resize(width, height, uid, fix_point):


### PR DESCRIPTION
Fixes the `set_on_top` half of #1823.

`set_on_top` assigned `Form.TopMost` directly on the calling thread. Since pywebview runs `js_api` handlers on a worker thread (`util.js_bridge_call`: *"executed in a separate thread to prevent blocking the UI thread"*), this is an unmarshaled cross-thread operation on a WinForms control, and the message pump can deadlock permanently while the system is doing window-activation work — the window goes to "Not Responding", with no exception to catch.

Every other window operation in this backend already marshals via `Invoke` (`show`, `hide`, `toggle_fullscreen`, `maximize`, `minimize`, `restore`); `set_on_top` was the exception. This applies the same pattern, with the `InvokeRequired` guard used by `toggle_fullscreen` so calls already on the GUI thread stay direct.

### Verification

This is what #1823 was missing: the reporter there notes the deadlock could not be reproduced synthetically in four attempts, so the fix could not be verified either.

On our side it reproduced reliably, with a much simpler trigger than the one in that report — no Excel, no `AppActivate`, no occlusion/throttling window:

1. Set `window.on_top = True` from a `js_api` handler (so it runs on the worker thread).
2. Move any other window behind the pinned one.

The app hangs. With this change applied as a client-side workaround through `window.native`, the hang is gone: it has been installed on several Windows machines in daily production use with no recurrence.

Environment: pywebview 6.2.1, EdgeChromium (WebView2 / WinForms), Windows 10/11 x64, frozen with PyInstaller. The GTK backend is unaffected — its `set_on_top` already defers with `glib.idle_add`.

### Notes

- Scope is deliberately limited to `set_on_top`. The `create_file_dialog` half of #1823 is untouched, since we don't use that path and could not verify a change to it.
- #1823 suggests `BeginInvoke` for this. I used `Invoke` to match every other operation in the file; happy to switch if you prefer the non-blocking variant here.
