### PR TITLE
WinForms: Shift focus to menu bar when active

### DIFF
--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -546,6 +546,9 @@ class BrowserView:
                     elif isinstance(menu, MenuAction):
                         top_level_menu.Items.Add(create_action_item(menu))
 
+                top_level_menu.MenuActivate += lambda s, e: top_level_menu.Focus()
+                top_level_menu.MenuDeactivate += lambda s, e: self.browser.webview.Focus()
+
                 self.Controls.Add(top_level_menu)
 
             if self.InvokeRequired:

--- a/webview/platforms/winforms.py
+++ b/webview/platforms/winforms.py
@@ -547,7 +547,9 @@ class BrowserView:
                         top_level_menu.Items.Add(create_action_item(menu))
 
                 top_level_menu.MenuActivate += lambda s, e: top_level_menu.Focus()
-                top_level_menu.MenuDeactivate += lambda s, e: self.browser.webview.Focus()
+                top_level_menu.MenuDeactivate += lambda s, e: (
+                    CEF.focus(self.uid) if is_cef else self.browser.webview.Focus()
+                )
 
                 self.Controls.Add(top_level_menu)
 


### PR DESCRIPTION
This allows keyboard navigation of the menu bar and fixes #1834 

Note: Alt+F style &File menu mnemonics are not supported with this change. They would require more complex forwarding of keystrokes.

Verified by running examples/menu.py with the change.